### PR TITLE
Fixed Secure LDAP using SSL checkbox value

### DIFF
--- a/src/views/SecurityAndAccess/Ldap/Ldap.vue
+++ b/src/views/SecurityAndAccess/Ldap/Ldap.vue
@@ -375,7 +375,10 @@ export default {
       const serverUri = serviceAddress
         ? serviceAddress.replace(/ldaps?:\/\//, '')
         : '';
-      this.form.secureLdapEnabled = secureLdap;
+      this.form.secureLdapEnabled =
+        !this.caCertificateExpiration || !this.ldapCertificateExpiration
+          ? false
+          : secureLdap;
       this.form.serverUri = serverUri;
       this.form.bindDn = bindDn;
       this.form.bindPassword = '';


### PR DESCRIPTION
- When the CA Certificate and LDAP Certificate are present, We can set the Secure LDAP using SSL checkbox value as true or false.
- When either of the two are NOT present, the checkbox is not editable and also the checkbox value must be false.
- BQ defect: https://w3.rchland.ibm.com/projects/bestquest/?defect=SW555139

Signed-off-by: Nikhil Ashoka <a.nikhil@ibm.com>