### PR TITLE
Hotfixed Frequency cap save button

### DIFF
--- a/src/views/ResourceManagement/SystemParameters/FrequencyCap.vue
+++ b/src/views/ResourceManagement/SystemParameters/FrequencyCap.vue
@@ -76,7 +76,7 @@
               type="submit"
               :disabled="!frequencyRequestCurrentToggle"
               class="mt-3 mb-3"
-              @click="saveFrequencyRequest"
+              @click.prevent="saveFrequencyRequest"
             >
               {{ $t('global.action.save') }}
             </b-button>


### PR DESCRIPTION
Frequency cap save button was browser refreshing
the page on the first click and that wasn't the
intended action

- Add prevent modifier to the button
Signed-off-by: Sandeepa Singh [sandeepa.singh@ibm.com](mailto:sandeepa.singh@ibm.com)