### PR TITLE
Changed connection status logic for Hypervisor console

### DIFF
--- a/src/views/Operations/ServiceLoginConsoles/ServiceLoginConsoles.vue
+++ b/src/views/Operations/ServiceLoginConsoles/ServiceLoginConsoles.vue
@@ -69,7 +69,9 @@ export default {
       if (this.consoleType === 'bmc-console') status = this.wsConnection;
       if (this.consoleType === 'console1')
         status =
-          this.$store.getters['global/isInPhypStandby'] && this.wsConnection;
+          this.$store.getters['chassis/powerState'] !== 'Off' &&
+          this.wsConnection;
+
       return status;
     },
     serverStatusIcon() {


### PR DESCRIPTION
We were told to make the connection status logic for
the Hypervisor console be the same as the Host console.
The previous logic was incorrect because the Hypervisor
console does open long before PHYP STANDBY.

-Changed the connection status logic of Hypervisor
console to be the same as the Host console.

Signed-off-by: Sandeepa Singh [sandeepa.singh@ibm.com](mailto:sandeepa.singh@ibm.com)

BQ Ref

[SW555293](https://w3.rchland.ibm.com/projects/bestquest/?defect=SW555293) : FTC1030:Everest:Hypervision console status showing as Disconnect