### PR TITLE
Updated the text of server power ops documentation

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -1282,6 +1282,7 @@
       "currentOperatingMode": "Current operating mode %{currOptMode}",
       "defaultPartition": "Default partition environment",
       "ibmIPartition": "IBM i partition boot mode",
+      "nonHMCManaged": "Enabled only when the system is non HMC-managed",
       "powPolicySection": "will be set to %{powerPolicy}",
       "pvm_default_os_type": "Default partition environment",
       "pvm_os_boot_type": "IBM i partition boot mode",

--- a/src/views/Operations/ServerPowerOperations/BiosSettings.vue
+++ b/src/views/Operations/ServerPowerOperations/BiosSettings.vue
@@ -211,16 +211,19 @@
               {{
                 $t('pageServerPowerOperations.biosSettings.defaultPartition')
               }}
+              ({{ $t('pageServerPowerOperations.biosSettings.nonHMCManaged') }})
             </template>
           </b-table>
           <b-table stacked="sm" hover :items="aixPartitionItems" caption-top>
             <template #table-caption>
               {{ $t('pageServerPowerOperations.biosSettings.aixLinux') }}
+              ({{ $t('pageServerPowerOperations.biosSettings.nonHMCManaged') }})
             </template>
           </b-table>
           <b-table stacked="sm" hover :items="ibmiItems" caption-top>
             <template #table-caption>
               {{ $t('pageServerPowerOperations.biosSettings.ibmIPartition') }}
+              ({{ $t('pageServerPowerOperations.biosSettings.nonHMCManaged') }})
             </template>
           </b-table>
         </b-collapse>


### PR DESCRIPTION
- The options:
   Default partition environment, AIX/LINUX partition boot mode
   and IBM i partition boot mode are only enabled when the system is
   non HMC-managed. Hence updated the text in the documentation section
   that suggested the same.
- BQ defect: https://w3.rchland.ibm.com/projects/bestquest/?defect=SW555796

Signed-off-by: Nikhil Ashoka <a.nikhil@ibm.com>