### PR TITLE
Add text on user management page

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -1477,7 +1477,8 @@
       "unlock": "Unlock",
       "username": "Username",
       "userPassword": "User password",
-      "userUnlockMethod": "User unlock method"
+      "userUnlockMethod": "User unlock method",
+      "zeroLoginAttempts": "If `0`, then account shall never be locked."
     },
     "table": {
       "privilege": "Privilege",

--- a/src/views/SecurityAndAccess/UserManagement/ModalSettings.vue
+++ b/src/views/SecurityAndAccess/UserManagement/ModalSettings.vue
@@ -21,6 +21,9 @@
                   })
                 }}
               </b-form-text>
+              <b-form-text>{{
+                $t('pageUserManagement.modal.zeroLoginAttempts')
+              }}</b-form-text>
               <b-form-input
                 id="lockout-threshold"
                 v-model.number="form.lockoutThreshold"


### PR DESCRIPTION
Added help text on user management page to let the user know that if AccountLockoutThreshold (Max failed login attempts before locking user) is set to zero then the user will never be locked.

Signed-off-by: Sandeepa Singh <[sandeepa.singh@ibm.com](mailto:sandeepa.singh@ibm.com)>