### PR TITLE
Remove dump download option from overview page

### DIFF
--- a/src/views/Overview/OverviewDumps.vue
+++ b/src/views/Overview/OverviewDumps.vue
@@ -1,8 +1,6 @@
 <template>
   <overview-card
     :data="dumps"
-    :disabled="dumps.length === 0"
-    :download-button="true"
     :file-name="exportFileNameByDate()"
     :title="$t('pageOverview.dumps')"
     :to="`/logs/dumps`"


### PR DESCRIPTION
Remove dump download option from overview page

 Signed-off-by: Sandeepa Singh <[sandeepa.singh@ibm.com](mailto:sandeepa.singh@ibm.com)>
 
 BQ defect:
 [SW553721](https://w3.rchland.ibm.com/projects/bestquest/?defect=SW553721) : FVTR1020:Rainier:GUI: Overview page Dumps information Download link doesn't download the actual dumps available