### PR TITLE
Error message displayed if fails to authenticate the user

### DIFF
--- a/src/store/modules/Authentication/AuthenticanStore.js
+++ b/src/store/modules/Authentication/AuthenticanStore.js
@@ -58,13 +58,16 @@ const AuthenticationStore = {
         .then(() => router.replace('/login'))
         .catch((error) => console.log(error));
     },
-    async checkPasswordChangeRequired(_, username) {
+    async checkPasswordChangeRequired({ commit }, username) {
       return api
         .get(`/redfish/v1/AccountService/Accounts/${username}`)
         .then(({ data: { PasswordChangeRequired } }) => {
           return PasswordChangeRequired;
         })
-        .catch((error) => console.log(error));
+        .catch((error) => {
+          commit('authError');
+          console.log(error);
+        });
     },
     async dateAndTime({ commit }) {
       return api


### PR DESCRIPTION
- In the scenario of rare cases, If login is successful but
  unable to authenticate the user and fails to proceed, there is
  no information and confuses the user. Hence, a back-up error
  message is added here.
- BQ defect: https://w3.rchland.ibm.com/projects/bestquest/?defect=SW555861

Signed-off-by: Nikhil Ashoka <a.nikhil@ibm.com>