### PR TITLE
Renamed Resolution in Event logs

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -519,7 +519,7 @@
       "id": "ID",
       "modifiedDate": "Modified Date",
       "name": "Name",
-      "resolution": "Resolution",
+      "resolution": "Resolution (callout)",
       "searchLogs": "Search logs",
       "severity": "Severity",
       "status": "Status",


### PR DESCRIPTION
- Renamed "Resolution" as "Resolution (callout)" in Event logs page

Signed-off-by: Nikhil Ashoka <a.nikhil@ibm.com>