### PR TITLE
Memory page made HMC-managed independent

### DIFF
--- a/src/views/ResourceManagement/Memory/Memory.vue
+++ b/src/views/ResourceManagement/Memory/Memory.vue
@@ -326,9 +326,6 @@ export default {
     serverStatus() {
       return this.$store.getters['global/serverStatus'];
     },
-    hmcManaged() {
-      return this.$store.getters['resourceMemory/hmcManaged'];
-    },
   },
   watch: {
     logicalMemorySize: function (value) {
@@ -368,11 +365,8 @@ export default {
     isServerOff() {
       return this.serverStatus === 'off' ? true : false;
     },
-    isHmcManaged() {
-      return this.hmcManaged === 'Enabled' ? true : false;
-    },
     isSectionEditable() {
-      return this.isServerOff() && !this.isHmcManaged();
+      return this.isServerOff();
     },
     handleSubmit() {
       this.startLoader();


### PR DESCRIPTION
- Editable section of the Memory page was HMC-managed dependent, Made it independent.
- BQ defect: https://w3.rchland.ibm.com/projects/bestquest/?defect=FW725233
- BQ defect: https://w3.rchland.ibm.com/projects/bestquest/?defect=SW555488

Signed-off-by: Nikhil Ashoka <a.nikhil@ibm.com>