### PR TITLE
Add success toast

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -768,7 +768,9 @@
       "errorEnableSystemAttentionLed": "Error enabling System Attention LED.",
       "errorEnclosureSettings": "Error updating enclosure settings.",
       "infoRemoveAssembly": "Refresh to confirm whether '%{assemblyName}' is ready to  be removed.",
-      "successEnclosureSettings": "Successfully updated enclosure settings."
+      "successEnclosureSettings": "Successfully updated enclosure settings.",
+      "successEnableIdentifyLed": "Successfully enabled Identify LED.",
+      "successDisableIdentifyLed": "Successfully disabled Identify LED."
     }
   },
   "pageKeyClear": {

--- a/src/store/modules/HardwareStatus/AssemblyStore.js
+++ b/src/store/modules/HardwareStatus/AssemblyStore.js
@@ -57,17 +57,28 @@ const AssemblyStore = {
         ],
       };
 
-      return await api.patch(uri, updatedIdentifyLedValue).catch((error) => {
-        dispatch('getAssemblyInfo');
-        console.log('error', error);
-        if (led.identifyLed) {
-          throw new Error(i18n.t('pageInventory.toast.errorEnableIdentifyLed'));
-        } else {
-          throw new Error(
-            i18n.t('pageInventory.toast.errorDisableIdentifyLed')
-          );
-        }
-      });
+      return await api
+        .patch(uri, updatedIdentifyLedValue)
+        .then(() => {
+          if (led.identifyLed) {
+            return i18n.t('pageInventory.toast.successEnableIdentifyLed');
+          } else {
+            return i18n.t('pageInventory.toast.successDisableIdentifyLed');
+          }
+        })
+        .catch((error) => {
+          dispatch('getAssemblyInfo');
+          console.log('error', error);
+          if (led.identifyLed) {
+            throw new Error(
+              i18n.t('pageInventory.toast.errorEnableIdentifyLed')
+            );
+          } else {
+            throw new Error(
+              i18n.t('pageInventory.toast.errorDisableIdentifyLed')
+            );
+          }
+        });
     },
   },
 };

--- a/src/store/modules/HardwareStatus/BmcStore.js
+++ b/src/store/modules/HardwareStatus/BmcStore.js
@@ -43,7 +43,14 @@ const BmcStore = {
       };
       return await api
         .patch(uri, updatedIdentifyLedValue)
-        .then(() => dispatch('getBmcInfo'))
+        .then(() => {
+          dispatch('getBmcInfo');
+          if (led.identifyLed) {
+            return i18n.t('pageInventory.toast.successEnableIdentifyLed');
+          } else {
+            return i18n.t('pageInventory.toast.successDisableIdentifyLed');
+          }
+        })
         .catch((error) => {
           dispatch('getBmcInfo');
           console.log('error', error);

--- a/src/store/modules/HardwareStatus/ChassisStore.js
+++ b/src/store/modules/HardwareStatus/ChassisStore.js
@@ -58,7 +58,14 @@ const ChassisStore = {
       };
       return await api
         .patch(uri, updatedIdentifyLedValue)
-        .then(() => dispatch('getChassisInfo'))
+        .then(() => {
+          dispatch('getChassisInfo');
+          if (led.identifyLed) {
+            return i18n.t('pageInventory.toast.successEnableIdentifyLed');
+          } else {
+            return i18n.t('pageInventory.toast.successDisableIdentifyLed');
+          }
+        })
         .catch((error) => {
           dispatch('getChassisInfo');
           console.log('error', error);

--- a/src/store/modules/HardwareStatus/FanStore.js
+++ b/src/store/modules/HardwareStatus/FanStore.js
@@ -62,16 +62,27 @@ const FanStore = {
       const updatedIdentifyLedValue = {
         LocationIndicatorActive: led.identifyLed,
       };
-      return await api.patch(uri, updatedIdentifyLedValue).catch((error) => {
-        console.log(error);
-        if (led.identifyLed) {
-          throw new Error(i18n.t('pageInventory.toast.errorEnableIdentifyLed'));
-        } else {
-          throw new Error(
-            i18n.t('pageInventory.toast.errorDisableIdentifyLed')
-          );
-        }
-      });
+      return await api
+        .patch(uri, updatedIdentifyLedValue)
+        .then(() => {
+          if (led.identifyLed) {
+            return i18n.t('pageInventory.toast.successEnableIdentifyLed');
+          } else {
+            return i18n.t('pageInventory.toast.successDisableIdentifyLed');
+          }
+        })
+        .catch((error) => {
+          console.log(error);
+          if (led.identifyLed) {
+            throw new Error(
+              i18n.t('pageInventory.toast.errorEnableIdentifyLed')
+            );
+          } else {
+            throw new Error(
+              i18n.t('pageInventory.toast.errorDisableIdentifyLed')
+            );
+          }
+        });
     },
   },
 };

--- a/src/store/modules/HardwareStatus/MemoryStore.js
+++ b/src/store/modules/HardwareStatus/MemoryStore.js
@@ -57,17 +57,28 @@ const MemoryStore = {
       const updatedIdentifyLedValue = {
         LocationIndicatorActive: led.identifyLed,
       };
-      return await api.patch(uri, updatedIdentifyLedValue).catch((error) => {
-        dispatch('getDimms');
-        console.log('error', error);
-        if (led.identifyLed) {
-          throw new Error(i18n.t('pageInventory.toast.errorEnableIdentifyLed'));
-        } else {
-          throw new Error(
-            i18n.t('pageInventory.toast.errorDisableIdentifyLed')
-          );
-        }
-      });
+      return await api
+        .patch(uri, updatedIdentifyLedValue)
+        .then(() => {
+          if (led.identifyLed) {
+            return i18n.t('pageInventory.toast.successEnableIdentifyLed');
+          } else {
+            return i18n.t('pageInventory.toast.successDisableIdentifyLed');
+          }
+        })
+        .catch((error) => {
+          dispatch('getDimms');
+          console.log('error', error);
+          if (led.identifyLed) {
+            throw new Error(
+              i18n.t('pageInventory.toast.errorEnableIdentifyLed')
+            );
+          } else {
+            throw new Error(
+              i18n.t('pageInventory.toast.errorDisableIdentifyLed')
+            );
+          }
+        });
     },
   },
 };

--- a/src/store/modules/HardwareStatus/PcieSlotsStore.js
+++ b/src/store/modules/HardwareStatus/PcieSlotsStore.js
@@ -44,7 +44,14 @@ const PcieSlotsStore = {
       };
       return await api
         .patch(`${led.uri}/PCIeSlots`, updatedIdentifyLedValue)
-        .then(() => dispatch('getPcieSlotsInfo', { uri: led.uri }))
+        .then(() => {
+          dispatch('getPcieSlotsInfo', { uri: led.uri });
+          if (led.identifyLed) {
+            return i18n.t('pageInventory.toast.successEnableIdentifyLed');
+          } else {
+            return i18n.t('pageInventory.toast.successDisableIdentifyLed');
+          }
+        })
         .catch((error) => {
           dispatch('getPcieSlotsInfo', { uri: led.uri });
           console.log('error', error);

--- a/src/store/modules/HardwareStatus/ProcessorStore.js
+++ b/src/store/modules/HardwareStatus/ProcessorStore.js
@@ -64,17 +64,28 @@ const ProcessorStore = {
       const updatedIdentifyLedValue = {
         LocationIndicatorActive: led.identifyLed,
       };
-      return await api.patch(uri, updatedIdentifyLedValue).catch((error) => {
-        dispatch('getProcessorsInfo');
-        console.log('error', error);
-        if (led.identifyLed) {
-          throw new Error(i18n.t('pageInventory.toast.errorEnableIdentifyLed'));
-        } else {
-          throw new Error(
-            i18n.t('pageInventory.toast.errorDisableIdentifyLed')
-          );
-        }
-      });
+      return await api
+        .patch(uri, updatedIdentifyLedValue)
+        .then(() => {
+          if (led.identifyLed) {
+            return i18n.t('pageInventory.toast.successEnableIdentifyLed');
+          } else {
+            return i18n.t('pageInventory.toast.successDisableIdentifyLed');
+          }
+        })
+        .catch((error) => {
+          dispatch('getProcessorsInfo');
+          console.log('error', error);
+          if (led.identifyLed) {
+            throw new Error(
+              i18n.t('pageInventory.toast.errorEnableIdentifyLed')
+            );
+          } else {
+            throw new Error(
+              i18n.t('pageInventory.toast.errorDisableIdentifyLed')
+            );
+          }
+        });
     },
   },
 };

--- a/src/store/modules/HardwareStatus/SystemStore.js
+++ b/src/store/modules/HardwareStatus/SystemStore.js
@@ -46,6 +46,13 @@ const SystemStore = {
         .patch('/redfish/v1/Systems/system', {
           LocationIndicatorActive: ledState,
         })
+        .then(() => {
+          if (ledState) {
+            return i18n.t('pageInventory.toast.successEnableIdentifyLed');
+          } else {
+            return i18n.t('pageInventory.toast.successDisableIdentifyLed');
+          }
+        })
         .catch((error) => {
           commit('setSystemInfo', this.state.system.systems[0]);
           console.log('error', error);
@@ -70,6 +77,13 @@ const SystemStore = {
             },
           },
         })
+        .then(() => {
+          if (ledState) {
+            return i18n.t('pageInventory.toast.successEnableIdentifyLed');
+          } else {
+            return i18n.t('pageInventory.toast.successDisableIdentifyLed');
+          }
+        })
         .catch((error) => {
           commit('setSystemInfo', this.state.system.systems[0]);
           console.log('error', error);
@@ -88,6 +102,13 @@ const SystemStore = {
               LampTest: lampTestState,
             },
           },
+        })
+        .then(() => {
+          if (lampTestState) {
+            return i18n.t('pageInventory.toast.successEnableIdentifyLed');
+          } else {
+            return i18n.t('pageInventory.toast.successDisableIdentifyLed');
+          }
         })
         .catch((error) => {
           commit('setSystemInfo', this.state.system.systems[0]);

--- a/src/views/HardwareStatus/Inventory/InventoryServiceIndicator.vue
+++ b/src/views/HardwareStatus/Inventory/InventoryServiceIndicator.vue
@@ -123,16 +123,22 @@ export default {
   },
   methods: {
     toggleIdentifyLedSwitch(ledState) {
-      this.$store.dispatch('system/changeIdentifyLedState', ledState);
+      this.$store
+        .dispatch('system/changeIdentifyLedState', ledState)
+        .then((message) => this.successToast(message))
+        .catch(({ message }) => this.errorToast(message));
     },
     toggleSystemAttentionLedSwitch(systemLedState) {
-      this.$store.dispatch(
-        'system/changeSystemAttentionLedState',
-        systemLedState
-      );
+      this.$store
+        .dispatch('system/changeSystemAttentionLedState', systemLedState)
+        .then((message) => this.successToast(message))
+        .catch(({ message }) => this.errorToast(message));
     },
     toggleLampTestSwitch(lampTestState) {
-      this.$store.dispatch('system/changeLampTestState', lampTestState);
+      this.$store
+        .dispatch('system/changeLampTestState', lampTestState)
+        .then((message) => this.successToast(message))
+        .catch(({ message }) => this.errorToast(message));
     },
   },
 };

--- a/src/views/HardwareStatus/Inventory/InventoryTableAssembly.vue
+++ b/src/views/HardwareStatus/Inventory/InventoryTableAssembly.vue
@@ -263,6 +263,7 @@ export default {
           memberId: row.id,
           identifyLed: row.identifyLed,
         })
+        .then((message) => this.successToast(message))
         .catch(({ message }) => this.errorToast(message));
     },
     hasIdentifyLed(identifyLed) {

--- a/src/views/HardwareStatus/Inventory/InventoryTableBmcManager.vue
+++ b/src/views/HardwareStatus/Inventory/InventoryTableBmcManager.vue
@@ -160,6 +160,7 @@ export default {
           uri: row.uri,
           identifyLed: row.identifyLed,
         })
+        .then((message) => this.successToast(message))
         .catch(({ message }) => this.errorToast(message));
     },
     // TO DO: remove hasIdentifyLed method once the following story is merged:

--- a/src/views/HardwareStatus/Inventory/InventoryTableChassis.vue
+++ b/src/views/HardwareStatus/Inventory/InventoryTableChassis.vue
@@ -149,6 +149,7 @@ export default {
           uri: row.uri,
           identifyLed: row.identifyLed,
         })
+        .then((message) => this.successToast(message))
         .catch(({ message }) => this.errorToast(message));
     },
     // TO DO: Remove this method when the LocationIndicatorActive is added from backend.

--- a/src/views/HardwareStatus/Inventory/InventoryTableDimmSlot.vue
+++ b/src/views/HardwareStatus/Inventory/InventoryTableDimmSlot.vue
@@ -221,6 +221,7 @@ export default {
           uri: row.uri,
           identifyLed: row.identifyLed,
         })
+        .then((message) => this.successToast(message))
         .catch(({ message }) => this.errorToast(message));
     },
   },

--- a/src/views/HardwareStatus/Inventory/InventoryTableFans.vue
+++ b/src/views/HardwareStatus/Inventory/InventoryTableFans.vue
@@ -256,6 +256,7 @@ export default {
           uri: row.uri,
           identifyLed: row.identifyLed,
         })
+        .then((message) => this.successToast(message))
         .catch(({ message }) => this.errorToast(message));
     },
   },

--- a/src/views/HardwareStatus/Inventory/InventoryTablePcieSlots.vue
+++ b/src/views/HardwareStatus/Inventory/InventoryTablePcieSlots.vue
@@ -205,6 +205,7 @@ export default {
           identifyLed: row.identifyLed,
           uri: this.chassis,
         })
+        .then((message) => this.successToast(message))
         .catch(({ message }) => this.errorToast(message));
     },
   },

--- a/src/views/HardwareStatus/Inventory/InventoryTableProcessors.vue
+++ b/src/views/HardwareStatus/Inventory/InventoryTableProcessors.vue
@@ -214,6 +214,7 @@ export default {
           uri: row.uri,
           identifyLed: row.identifyLed,
         })
+        .then((message) => this.successToast(message))
         .catch(({ message }) => this.errorToast(message));
     },
     // TO DO: remove hasIdentifyLed when the following is merged:


### PR DESCRIPTION
Success toast messages were missing on Inventory page. 

 - Added success toast message for toggle switches on inventory page for consistency across GUI.
 
 Signed-off-by: Sandeepa Singh <[sandeepa.singh@ibm.com](mailto:sandeepa.singh@ibm.com)>
 
 BQ defect link: [SW556549 ](https://w3.rchland.ibm.com/projects/bestquest/?defect=SW556549): FTC1030: Everest: No notification after changing identify led on hardware inventory page