### PR TITLE
Update password helptext

### DIFF
--- a/src/components/Global/InfoTooltipPassword.vue
+++ b/src/components/Global/InfoTooltipPassword.vue
@@ -25,6 +25,8 @@
         {{ $t('global.passwordValidation.message5') }}
         <br />
         {{ $t('global.passwordValidation.message6') }}
+        <br />
+        {{ $t('global.passwordValidation.message7') }}
       </p>
     </b-tooltip>
   </span>

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -64,7 +64,8 @@
       "message3": "3. Not contain the account username",
       "message4": "4. Not contain a dictionary word",
       "message5": "5. Not contain sequential characters",
-      "message6": "6. Must be 20 characters or less if used for IPMI"
+      "message6": "6. Must be 20 characters or less if used for IPMI",
+      "message7": "7. Must contain any two from lowercase letters, uppercase letters, digits and other characters"
     },
     "status": {
       "absent": "Absent",


### PR DESCRIPTION
Updated the help text for password. The new password must have characters from at least two classes: lowercase letters, uppercase letters, digits, and other characters.

Signed-off-by: Sandeepa Singh <[sandeepa.singh@ibm.com](mailto:sandeepa.singh@ibm.com)>