### PR TITLE
Rename button the save settings button

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -22,7 +22,6 @@
       "replace": "Replace",
       "reset": "Reset",
       "save": "Save",
-      "saveSettings": "Save settings",
       "selected": "Selected"
     },
     "ariaLabel": {

--- a/src/views/ProfileSettings/ProfileSettings.vue
+++ b/src/views/ProfileSettings/ProfileSettings.vue
@@ -130,7 +130,7 @@
         type="submit"
         data-test-id="profileSettings-button-saveSettings"
       >
-        {{ $t('global.action.saveSettings') }}
+        {{ $t('global.action.save') }}
       </b-button>
     </b-form>
   </b-container>

--- a/src/views/SecurityAndAccess/Ldap/Ldap.vue
+++ b/src/views/SecurityAndAccess/Ldap/Ldap.vue
@@ -216,7 +216,7 @@
               data-test-id="ldap-button-saveSettings"
               :disabled="loading"
             >
-              {{ $t('global.action.saveSettings') }}
+              {{ $t('global.action.save') }}
             </b-btn>
           </b-col>
         </b-row>

--- a/src/views/Settings/DateTime/DateTime.vue
+++ b/src/views/Settings/DateTime/DateTime.vue
@@ -205,7 +205,7 @@
             type="submit"
             data-test-id="dateTime-button-saveSettings"
           >
-            {{ $t('global.action.saveSettings') }}
+            {{ $t('global.action.save') }}
           </b-button>
         </b-form-group>
       </b-form>

--- a/src/views/Settings/PowerRestorePolicy/PowerRestorePolicy.vue
+++ b/src/views/Settings/PowerRestorePolicy/PowerRestorePolicy.vue
@@ -42,7 +42,7 @@
       type="submit"
       @click="submitForm"
     >
-      {{ $t('global.action.saveSettings') }}
+      {{ $t('global.action.save') }}
     </b-button>
   </b-container>
 </template>


### PR DESCRIPTION
For consistency on the GUI, the save settings button has been renamed to save

Signed-off-by: Sandeepa Singh <[sandeepa.singh@ibm.com](mailto:sandeepa.singh@ibm.com)>