### PR TITLE
Fix network eth1 error

### DIFF
--- a/src/store/modules/Settings/NetworkStore.js
+++ b/src/store/modules/Settings/NetworkStore.js
@@ -59,7 +59,7 @@ const NetworkStore = {
     },
   },
   actions: {
-    async getEthernetData({ commit }) {
+    async getEthernetData({ commit, state }) {
       return await api
         .get('/redfish/v1/Managers/bmc/EthernetInterfaces')
         .then((response) =>
@@ -80,7 +80,14 @@ const NetworkStore = {
           );
 
           commit('setNetworkSettings', ethernetInterfaces);
-          commit('setSelectedInterfaceId', ethernetData[0].Id);
+          let currentInterfaceIndex = 0;
+          if (state.selectedInterfaceIndex) {
+            currentInterfaceIndex = state.selectedInterfaceIndex;
+          }
+          commit(
+            'setSelectedInterfaceId',
+            ethernetData[currentInterfaceIndex].Id
+          );
         })
         .catch((error) => {
           console.log('Network Data:', error);


### PR DESCRIPTION
While trying to modify the eth1 ip address, the system was going into bad state. 

- Fixed the patch call which was resulting in error when modifying ip address for second time.

Signed-off-by: Sandeepa Singh <[sandeepa.singh@ibm.com](mailto:sandeepa.singh@ibm.com)>

BQ defect: [SW556598](https://w3.rchland.ibm.com/projects/bestquest/?defect=SW556598) : FTC1030:Rainier:Network:GUI- Modifying eth1 IP multiple times cause eth0 to lose its network configuration