### PR TITLE
Sensors table now updating on refresh

### DIFF
--- a/src/store/modules/HardwareStatus/SensorsStore.js
+++ b/src/store/modules/HardwareStatus/SensorsStore.js
@@ -1,5 +1,4 @@
 import api from '@/store/api';
-import { uniqBy } from 'lodash';
 
 const SensorsStore = {
   namespaced: true,
@@ -10,9 +9,7 @@ const SensorsStore = {
     sensors: (state) => state.sensors,
   },
   mutations: {
-    setSensors: (state, sensors) => {
-      state.sensors = uniqBy([...state.sensors, ...sensors], 'name');
-    },
+    setSensors: (state, sensors) => (state.sensors = sensors),
   },
   actions: {
     async getChassisCollection() {
@@ -24,7 +21,8 @@ const SensorsStore = {
         )
         .catch((error) => console.log(error));
     },
-    async getAllSensors({ dispatch }) {
+    async getAllSensors({ commit, dispatch }) {
+      commit('setSensors', []);
       const collection = await dispatch('getChassisCollection');
       if (!collection) return;
       return await api


### PR DESCRIPTION
- Sensors page was not updating on refresh. On refresh now, we are removing the values present and adding to the table from the beginning.
- BQ defect: https://w3.rchland.ibm.com/projects/bestquest/?defect=SW556657

Signed-off-by: Nikhil Ashoka <a.nikhil@ibm.com>