### PR TITLE
Secure LDAP is disabled when LDAP authentication disables

### DIFF
--- a/src/views/SecurityAndAccess/Ldap/Ldap.vue
+++ b/src/views/SecurityAndAccess/Ldap/Ldap.vue
@@ -375,10 +375,11 @@ export default {
       const serverUri = serviceAddress
         ? serviceAddress.replace(/ldaps?:\/\//, '')
         : '';
-      this.form.secureLdapEnabled =
-        !this.caCertificateExpiration || !this.ldapCertificateExpiration
-          ? false
-          : secureLdap;
+      this.form.secureLdapEnabled = !this.form.ldapAuthenticationEnabled
+        ? false
+        : !this.caCertificateExpiration || !this.ldapCertificateExpiration
+        ? false
+        : secureLdap;
       this.form.serverUri = serverUri;
       this.form.bindDn = bindDn;
       this.form.bindPassword = '';


### PR DESCRIPTION
- Secure LDAP was not getting disabled when the LDAP authentication disables. This change fixes this problem
- BQ defect: https://w3.rchland.ibm.com/projects/bestquest/?defect=SW556683

Signed-off-by: Nikhil Ashoka <a.nikhil@ibm.com>