### PR TITLE
Disable date and time page when host is up or ipling

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -316,7 +316,8 @@
   "pageDateTime": {
     "alert": {
       "link": "Profile Settings",
-      "message": "To change how date and time are displayed (either UTC or browser offset) throughout the application, visit "
+      "message": "To change how date and time are displayed (either UTC or browser offset) throughout the application, visit ",
+      "messageNtp": "If NTP is selected but an NTP server is not given or the given NTP server is not reachable, then time.google.com will be used."
     },
     "configureSettings": "Configure settings",
     "form": {

--- a/src/views/Settings/DateTime/DateTime.vue
+++ b/src/views/Settings/DateTime/DateTime.vue
@@ -32,10 +32,19 @@
       </b-row>
     </page-section>
     <page-section :section-title="$t('pageDateTime.configureSettings')">
+      <b-row>
+        <b-col md="8" xl="6">
+          <alert variant="info" class="mb-4">
+            <span>
+              {{ $t('pageDateTime.alert.messageNtp') }}
+            </span>
+          </alert>
+        </b-col>
+      </b-row>
       <b-form novalidate @submit.prevent="submitForm">
         <b-form-group
           label="Configure date and time"
-          :disabled="loading"
+          :disabled="loading || !isServerOff()"
           label-sr-only
         >
           <b-form-radio
@@ -311,6 +320,9 @@ export default {
       }
       return this.localOffset();
     },
+    serverStatus() {
+      return this.$store.getters['global/serverStatus'];
+    },
   },
   watch: {
     ntpServers() {
@@ -337,6 +349,9 @@ export default {
     ]).finally(() => this.endLoader());
   },
   methods: {
+    isServerOff() {
+      return this.serverStatus === 'off' ? true : false;
+    },
     emitChange() {
       if (this.$v.$invalid) return;
       this.$v.$reset(); //reset to re-validate on blur


### PR DESCRIPTION
The date and time page will be greyed out when the host is up or ipling.
- Add help text  for NTP

BQ defect link : 
- [SW556675](https://w3.rchland.ibm.com/projects/bestquest/?defect=SW556675) : GUI: Date and time page must be read-only when Host is up or ipling
- [SW556677](https://w3.rchland.ibm.com/projects/bestquest/?defect=SW556677) : GUI: Notify user the NTP server system is configured to


Signed-off-by: Sandeepa Singh <[sandeepa.singh@ibm.com](mailto:sandeepa.singh@ibm.com)>