### PR TITLE
Add info tooltip to frequency cap

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -825,6 +825,7 @@
     },
     "frequencyCap": "Frequency cap",
     "frequencyCapDescription": "When enabled, prevents all processors in the system from exceeding the specified maximum operating frequency, in MHz",
+    "frequencyCapHelpText": "If disabled, might require an initial boot to get the max and min frequency to be able to set.",
     "lateralCastOut": "Lateral cast out",
     "lateralCastOutDescription": "Only change this value if instructed by your service provider as it might degrade system performance.",
     "toast": {

--- a/src/views/ResourceManagement/SystemParameters/FrequencyCap.vue
+++ b/src/views/ResourceManagement/SystemParameters/FrequencyCap.vue
@@ -5,6 +5,9 @@
         <dl class="mt-3 mb-3 mr-3 w-75">
           <dt id="frequency-cap-label">
             {{ $t('pageSystemParameters.frequencyCap') }}
+            <info-tooltip
+              :title="$t('pageSystemParameters.frequencyCapHelpText')"
+            />
           </dt>
           <dd id="frequency-cap-description">
             {{ $t('pageSystemParameters.frequencyCapDescription') }}
@@ -88,6 +91,7 @@
 </template>
 
 <script>
+import InfoTooltip from '@/components/Global/InfoTooltip';
 import BVToastMixin from '@/components/Mixins/BVToastMixin';
 import DataFormatterMixin from '@/components/Mixins/DataFormatterMixin';
 import LoadingBarMixin from '@/components/Mixins/LoadingBarMixin';
@@ -96,6 +100,7 @@ import { requiredIf, between, numeric } from 'vuelidate/lib/validators';
 
 export default {
   name: 'FrequencyCap',
+  components: { InfoTooltip },
   mixins: [DataFormatterMixin, LoadingBarMixin, BVToastMixin, VuelidateMixin],
   props: {
     safeMode: {


### PR DESCRIPTION
Added a info tooltip to frequency cap to help user when the frequency cap is disabled

Signed-off-by: Sandeepa Singh <[sandeepa.singh@ibm.com](mailto:sandeepa.singh@ibm.com)>

BQ defect: 
[SW557159](https://w3.rchland.ibm.com/projects/bestquest/?defect=SW557159 ) : GUI: System Parameters: Add help text to Frequency cap for why it might be disabled



