### PR TITLE
New Error message displayed if fails to authenticate the user

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -897,6 +897,7 @@
     "uploadServiceLoginCertificate": "Upload service login certificate",
     "username": "Username",
     "alert": {
+      "unauthorizedMessage": "User unauthorized",
       "message": "Invalid username or password"
     },
     "modal": {

--- a/src/store/modules/Authentication/AuthenticanStore.js
+++ b/src/store/modules/Authentication/AuthenticanStore.js
@@ -7,12 +7,14 @@ const AuthenticationStore = {
   state: {
     loginPageDetails: {},
     authError: false,
+    failedAuth: false,
     xsrfCookie: Cookies.get('XSRF-TOKEN'),
     isAuthenticatedCookie: Cookies.get('IsAuthenticated'),
   },
   getters: {
     loginPageDetails: (state) => state.loginPageDetails,
     authError: (state) => state.authError,
+    failedAuth: (state) => state.failedAuth,
     isLoggedIn: (state) => {
       return (
         state.xsrfCookie !== undefined || state.isAuthenticatedCookie == 'true'
@@ -30,6 +32,9 @@ const AuthenticationStore = {
     authError(state, authError = true) {
       state.authError = authError;
     },
+    failedAuth(state, failedAuth = true) {
+      state.failedAuth = failedAuth;
+    },
     logout(state) {
       Cookies.remove('XSRF-TOKEN');
       Cookies.remove('IsAuthenticated');
@@ -43,6 +48,7 @@ const AuthenticationStore = {
   actions: {
     login({ commit }, { username, password }) {
       commit('authError', false);
+      commit('failedAuth', false);
       return api
         .post('/login', { data: [username, password] })
         .then(() => commit('authSuccess'))
@@ -65,7 +71,7 @@ const AuthenticationStore = {
           return PasswordChangeRequired;
         })
         .catch((error) => {
-          commit('authError');
+          commit('failedAuth');
           console.log(error);
         });
     },

--- a/src/views/Login/Login.vue
+++ b/src/views/Login/Login.vue
@@ -10,6 +10,11 @@
           {{ $t('pageLogin.alert.message') }}
         </p>
       </alert>
+      <alert class="login-error mb-4" :show="failedAuth" variant="danger">
+        <p id="login-error-alert">
+          {{ $t('pageLogin.alert.unauthorizedMessage') }}
+        </p>
+      </alert>
       <b-form-group label-for="language" :label="$t('pageLogin.language')">
         <b-form-select
           id="language"
@@ -143,6 +148,9 @@ export default {
   computed: {
     authError() {
       return this.$store.getters['authentication/authError'];
+    },
+    failedAuth() {
+      return this.$store.getters['authentication/failedAuth'];
     },
     loginPageDetails() {
       return this.$store.getters['authentication/loginPageDetails'];


### PR DESCRIPTION
-   In the scenario of rare cases, If login is successful but
    unable to authenticate the user and fails to proceed, there is
    error message "User unauthorized". Else if even unable to login, there is
    error message "Invalid username or password" displayed.
-   BQ defect: https://w3.rchland.ibm.com/projects/bestquest/?defect=SW555861

Signed-off-by: Nikhil Ashoka <a.nikhil@ibm.com>