### PR TITLE
Read only user will not be able to toggle switches

### DIFF
--- a/src/store/modules/GlobalStore.js
+++ b/src/store/modules/GlobalStore.js
@@ -73,6 +73,8 @@ const GlobalStore = {
       state.currentUser?.RoleId === 'OemIBMServiceAgent' || !state.currentUser,
     isAdminUser: (state) =>
       state.currentUser?.RoleId === 'Administrator' || !state.currentUser,
+    isReadOnlyUser: (state) =>
+      state.currentUser?.RoleId === 'ReadOnly' || !state.currentUser,
     isAuthorized: (state) => state.isAuthorized,
     isServiceLoginEnabled: (state) => state.isServiceLoginEnabled,
   },

--- a/src/views/Settings/HardwareDeconfiguration/MemoryDimms.vue
+++ b/src/views/Settings/HardwareDeconfiguration/MemoryDimms.vue
@@ -40,7 +40,7 @@
               v-model="row.item.settings"
               name="switch"
               switch
-              :disabled="!isServerOff || isBusy"
+              :disabled="!isServerOff || isBusy || isReadOnlyUser"
               @change="toggleSettingsSwitch(row)"
             >
               <span v-if="row.item.settings">
@@ -219,6 +219,9 @@ export default {
     },
     isServerOff() {
       return this.serverStatus === 'off' ? true : false;
+    },
+    isReadOnlyUser() {
+      return this.$store.getters['global/isReadOnlyUser'];
     },
   },
   created() {

--- a/src/views/Settings/HardwareDeconfiguration/ProcessorCores.vue
+++ b/src/views/Settings/HardwareDeconfiguration/ProcessorCores.vue
@@ -53,7 +53,7 @@
               v-model="row.item.settings"
               name="switch"
               switch
-              :disabled="!isServerOff || isBusy"
+              :disabled="!isServerOff || isBusy || isReadOnlyUser"
               @change="toggleSettingsSwitch(row)"
             >
               <span v-if="row.item.settings">
@@ -235,6 +235,9 @@ export default {
     },
     isServerOff() {
       return this.serverStatus === 'off' ? true : false;
+    },
+    isReadOnlyUser() {
+      return this.$store.getters['global/isReadOnlyUser'];
     },
   },
   created() {


### PR DESCRIPTION
Disabled the switches when the logged in user is read-only.

Signed-off-by: Sandeepa Singh <[sandeepa.singh@ibm.com](mailto:sandeepa.singh@ibm.com)>

BQ defect : [SW555862 ](https://w3.rchland.ibm.com/projects/bestquest/?defect=SW555862): FVTR1020.10:Rainier:CDM GUI:Incorrect error message displayed for read only user when configuring/deconfiguring dimm/core in HW deconfiguration page

