### PR TITLE
Additional message added on Disable SSH

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -1106,6 +1106,8 @@
     "usbFirmwareUpdatePolicyDescription": "Enabling the USB Firmware Update Policy will enable the functionality to allow firmware updates through a USB key.",
     "toast": {
       "errorNetworkPolicyUpdate": "Error updating %{policy}.",
+      "successDisableBmcShell": "Successfully disabled BMC shell (via SSH), Please allow 15 seconds for the disable to become effective.",
+      "successEnableBmcShell": "Successfully enabled BMC shell (via SSH)",
       "successNetworkPolicyUpdate": "Successfully updated %{policy}.",
       "successNextBootToast": "Applying changes to %{policy}. Changes made to %{policy} will take effect on next reboot."
     },

--- a/src/store/modules/SecurityAndAccess/PoliciesStore.js
+++ b/src/store/modules/SecurityAndAccess/PoliciesStore.js
@@ -177,9 +177,11 @@ const PoliciesStore = {
       return await api
         .patch('/redfish/v1/Managers/bmc/NetworkProtocol', ssh)
         .then(() => {
-          return i18n.t('pagePolicies.toast.successNetworkPolicyUpdate', {
-            policy: i18n.t('pagePolicies.ssh'),
-          });
+          if (protocolEnabled) {
+            return i18n.t('pagePolicies.toast.successEnableBmcShell');
+          } else {
+            return i18n.t('pagePolicies.toast.successDisableBmcShell');
+          }
         })
         .catch((error) => {
           console.log(error);


### PR DESCRIPTION
- On Disable SSH, there is a toast message which says, "Successfully disabled BMC shell (via SSH), Please allow 15 seconds for the disable to become effective."

- BQ defect: https://w3.rchland.ibm.com/projects/bestquest/?defect=SW533682

Signed-off-by: Nikhil Ashoka <a.nikhil@ibm.com>