### PR TITLE
Added Status and roles values to the translation file

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -75,6 +75,7 @@
       "enabled": "Enabled",
       "error": "Error",
       "informational": "Informational",
+      "locked": "Locked",
       "nextReboot": "Changes will take effect on next boot.",
       "notAvailable": "Not available",
       "off": "Off",
@@ -1518,10 +1519,13 @@
       "username": "Username"
     },
     "tableRoles": {
+      "administrator": "Administrator",
       "configureComponentsManagedByThisService": "Configure components managed by this service",
       "configureManagerResources": "Configure manager resources",
       "configureUsersAndTheirAccounts": "Configure users and their accounts",
       "logInToTheServiceAndReadResources": "Log in to the service and read resources",
+      "privilege": "Privilege",
+      "readOnly": "ReadOnly",
       "updatePasswordForCurrentUserAccount": "Update password for current user account"
     },
     "toast": {

--- a/src/views/SecurityAndAccess/UserManagement/TableRoles.vue
+++ b/src/views/SecurityAndAccess/UserManagement/TableRoles.vue
@@ -72,16 +72,16 @@ export default {
       fields: [
         {
           key: 'description',
-          label: this.$t('pageUserManagement.table.privilege'),
+          label: this.$t('pageUserManagement.tableRoles.privilege'),
         },
         {
           key: 'administrator',
-          label: this.$t('pageUserManagement.table.administrator'),
+          label: this.$t('pageUserManagement.tableRoles.administrator'),
           class: 'text-center',
         },
         {
           key: 'readonly',
-          label: this.$t('pageUserManagement.table.readOnly'),
+          label: this.$t('pageUserManagement.tableRoles.readOnly'),
           class: 'text-center',
         },
       ],

--- a/src/views/SecurityAndAccess/UserManagement/UserManagement.vue
+++ b/src/views/SecurityAndAccess/UserManagement/UserManagement.vue
@@ -223,10 +223,10 @@ export default {
           username: user.UserName,
           privilege: user.Description,
           status: user.Locked
-            ? 'Locked'
+            ? this.$t('global.status.locked')
             : user.Enabled
-            ? 'Enabled'
-            : 'Disabled',
+            ? this.$t('global.status.enabled')
+            : this.$t('global.status.disabled'),
           actions: [
             {
               value: 'edit',


### PR DESCRIPTION
- Status values were displayed directly from the redfish, Hence added the possible values to the translation file and using them.

- Roles headers were taken directly, Hence added them to the translation file and using them.

Signed-off-by: Nikhil Ashoka <a.nikhil@ibm.com>