### PR TITLE
Default partition value taken from translation file

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -1308,6 +1308,7 @@
     "biosSettings": {
       "aixLinux": "AIX/LINUX partition boot mode",
       "automatic": "Automatic",
+      "currentOperatingModeManual": "Current operating mode Manual",
       "currentOperatingModeNormal": "Current operating mode Normal",
       "defaultPartition": "Default partition environment",
       "ibmIPartition": "IBM i partition boot mode",
@@ -1381,6 +1382,12 @@
 }
 },
       "attributeValues": {
+        "pvm_default_os_type": {
+          "AIX": "AIX",
+          "Linux": "Linux",
+          "IBM I": "IBM I",
+          "Default": "Default"
+        },
         "pvm_os_boot_type": {
           "A_Mode": "A (Boot from disk using copy A)",
           "B_Mode": "B (Boot from disk using copy B)",

--- a/src/store/modules/Operations/BootSettingsStore.js
+++ b/src/store/modules/Operations/BootSettingsStore.js
@@ -122,6 +122,7 @@ const BootSettingsStore = {
                         value: item.ValueName,
                         text:
                           [
+                            'pvm_default_os_type',
                             'pvm_os_boot_type',
                             'pvm_rpa_boot_mode',
                             'pvm_stop_at_standby',

--- a/src/views/Operations/ServerPowerOperations/BiosSettings.vue
+++ b/src/views/Operations/ServerPowerOperations/BiosSettings.vue
@@ -100,7 +100,12 @@
                       $t(
                         `pageServerPowerOperations.biosSettings.powPolicySection`,
                         {
-                          powerPolicy: powerPolicy,
+                          powerPolicy:
+                            powerPolicy === 'AlwaysOff'
+                              ? $t(`pagePowerRestorePolicy.policies.AlwaysOff`)
+                              : powerPolicy === 'AlwaysOn'
+                              ? $t(`pagePowerRestorePolicy.policies.AlwaysOn`)
+                              : $t(`pagePowerRestorePolicy.policies.LastState`),
                         }
                       )
                     }}
@@ -111,7 +116,7 @@
                     <p>
                       {{
                         $t(
-                          `pageServerPowerOperations.biosSettings.currentOperatingMode`,
+                          `pageServerPowerOperations.biosSettings.currentOperatingModeManual`,
                           { currOptMode: currentOperatingMode }
                         )
                       }}
@@ -125,7 +130,12 @@
                       $t(
                         'pageServerPowerOperations.biosSettings.powPolicySection',
                         {
-                          powerPolicy: powerPolicy,
+                          powerPolicy:
+                            powerPolicy === 'AlwaysOff'
+                              ? $t(`pagePowerRestorePolicy.policies.AlwaysOff`)
+                              : powerPolicy === 'AlwaysOn'
+                              ? $t(`pagePowerRestorePolicy.policies.AlwaysOn`)
+                              : $t(`pagePowerRestorePolicy.policies.LastState`),
                         }
                       )
                     }}


### PR DESCRIPTION
- Default partition value taken from translation file to display in the UI
- Taking power restore policy value from the translation file instead of the taking directly from the redfish

Signed-off-by: Nikhil Ashoka <a.nikhil@ibm.com>