### PR TITLE
Displaying System Anchor value

### DIFF
--- a/src/views/ResourceManagement/CapacityOnDemand/CapacityOnDemandOrderInfo.vue
+++ b/src/views/ResourceManagement/CapacityOnDemand/CapacityOnDemandOrderInfo.vue
@@ -30,7 +30,7 @@
               <p>
                 {{ $t('pageCapacityOnDemand.orderInfo.systemAnchor') }}
                 <span class="font-weight-bold">
-                  {{ systemInfo.model || '--' }}
+                  {{ systemAnchor || '--' }}
                 </span>
               </p>
               <p>
@@ -224,6 +224,9 @@ export default {
     },
     systemInfo() {
       return this.$store.getters['system/systems']?.[0] || {};
+    },
+    systemAnchor() {
+      return this.licenses?.SystemAnchor?.SerialNumber;
     },
   },
 };


### PR DESCRIPTION
- In the Capacity on demand page, we were displaying the value from model. Now, that the new System Anchor is available under Licenses, the Serial Number is being displayed in the UI.
- BQ defect: https://w3.rchland.ibm.com/projects/bestquest/?defect=SW552204

Signed-off-by: Nikhil Ashoka <a.nikhil@ibm.com>