### PR TITLE
ips-localization: Change the width property size

### DIFF
--- a/src/components/AppHeader/AppHeader.vue
+++ b/src/components/AppHeader/AppHeader.vue
@@ -36,7 +36,7 @@
             data-test-id="appHeader-container-overview"
           >
             <img
-              width="50px"
+              width="100px"
               class="header-logo"
               src="@/assets/images/logo-header.svg"
               :alt="altLogo"

--- a/src/layouts/LoginLayout.vue
+++ b/src/layouts/LoginLayout.vue
@@ -5,7 +5,7 @@
         <div>
           <div class="login-brand mb-5">
             <img
-              width="90px"
+              width="150px"
               src="@/assets/images/login-company-logo.svg"
               :alt="altLogo"
             />


### PR DESCRIPTION
When loading the IPS logo, the original width value is too small, which is not suitable for the IPS logo.

Signed-off-by: George Liu <liuxiwei@inspur.com>