### PR TITLE
Refresh only once after login

### DIFF
--- a/src/views/Login/Login.vue
+++ b/src/views/Login/Login.vue
@@ -201,8 +201,7 @@ export default {
               this.$store.dispatch('global/getCurrentUser', username),
               this.$store.dispatch('global/getSystemInfo'),
             ]).then(() => {
-              this.$router.push('/');
-              location.reload();
+              location.href = '/';
             });
           }
         })


### PR DESCRIPTION
- Initially it was refreshing twice after the login to GUI, this is fixed.
- BQ defect: https://w3.rchland.ibm.com/projects/bestquest/?defect=SW557765

Signed-off-by: Nikhil Ashoka <a.nikhil@ibm.com>