### PR TITLE
Remove service login label for read only user

### DIFF
--- a/src/views/Overview/OverviewServer.vue
+++ b/src/views/Overview/OverviewServer.vue
@@ -28,11 +28,13 @@
           <dd v-else-if="operatingMode === 'Normal'">
             {{ $t('pageOverview.normal') }}
           </dd>
-          <dt>{{ $t('pageOverview.serviceLogin') }}</dt>
-          <dd>
-            <status-icon :status="serviceLoginStatusIcon" />
-            {{ dataFormatter(serviceLogin) }}
-          </dd>
+          <div v-if="!isReadOnlyUser">
+            <dt>{{ $t('pageOverview.serviceLogin') }}</dt>
+            <dd>
+              <status-icon :status="serviceLoginStatusIcon" />
+              {{ dataFormatter(serviceLogin) }}
+            </dd>
+          </div>
         </dl>
       </b-col>
     </b-row>
@@ -102,6 +104,9 @@ export default {
       },
       assetTag() {
         return this.$store.getters['global/assetTag'];
+      },
+      isReadOnlyUser() {
+        return this.$store.getters['global/isReadOnlyUser'];
       },
     }),
     serviceLoginStatusIcon() {


### PR DESCRIPTION
Remove service login label for read only user as it will show disabled for read only user and it might be confusing for the user.

Signed-off-by: Sandeepa Singh <[sandeepa.singh@ibm.com](mailto:sandeepa.singh@ibm.com)>

BW defect : [SW556469 ](https://w3.rchland.ibm.com/projects/bestquest/?defect=SW556469): FTC1030:Rainier:GUI: Service Login status comes as disabled in overview page with readonly user


