### PR TITLE
Added max limit based on selected user

### DIFF
--- a/src/views/SecurityAndAccess/UserManagement/UserManagement.vue
+++ b/src/views/SecurityAndAccess/UserManagement/UserManagement.vue
@@ -250,7 +250,7 @@ export default {
       return this.$store.getters['userManagement/accountSettings'];
     },
     passwordRequirements() {
-      if (this.currentUser?.AccountTypes?.includes('IPMI')) {
+      if (this.activeUser?.AccountTypes?.includes('IPMI')) {
         return {
           minLength: 8,
           maxLength: 20,


### PR DESCRIPTION
- Max limit was set based on the Current logged in user. But now the max limit is now set based on the selected user. Hence, there won't be any error message now.

- BQ defect: https://w3.rchland.ibm.com/projects/bestquest/?defect=SW557769

Signed-off-by: Nikhil Ashoka <a.nikhil@ibm.com>