### PR TITLE
Lamp test switch disabled once ON

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -848,7 +848,8 @@
       "infoRemoveAssembly": "Refresh to confirm whether '%{assemblyName}' is ready to  be removed.",
       "successEnclosureSettings": "Successfully updated enclosure settings.",
       "successEnableIdentifyLed": "Successfully enabled Identify LED.",
-      "successDisableIdentifyLed": "Successfully disabled Identify LED."
+      "successDisableIdentifyLed": "Successfully disabled Identify LED.",
+      "successEnableLampTest": "Successfully enabled Lamp test. The LEDs will stay on for 4 minutes."
     }
   },
   "pageKeyClear": {

--- a/src/store/modules/HardwareStatus/SystemStore.js
+++ b/src/store/modules/HardwareStatus/SystemStore.js
@@ -105,9 +105,7 @@ const SystemStore = {
         })
         .then(() => {
           if (lampTestState) {
-            return i18n.t('pageInventory.toast.successEnableIdentifyLed');
-          } else {
-            return i18n.t('pageInventory.toast.successDisableIdentifyLed');
+            return i18n.t('pageInventory.toast.successEnableLampTest');
           }
         })
         .catch((error) => {

--- a/src/views/HardwareStatus/Inventory/InventoryServiceIndicator.vue
+++ b/src/views/HardwareStatus/Inventory/InventoryServiceIndicator.vue
@@ -72,6 +72,7 @@
               <b-form-checkbox
                 id="lampSwitch"
                 v-model="systems.lampTest"
+                :disabled="systems.lampTest"
                 data-test-id="hardwareStatus-toggle-lampTest"
                 switch
                 @change="toggleLampTestSwitch"
@@ -100,6 +101,11 @@ import DataFormatterMixin from '@/components/Mixins/DataFormatterMixin';
 export default {
   components: { InfoTooltip, PageSection },
   mixins: [BVToastMixin, DataFormatterMixin],
+  data() {
+    return {
+      isLampTestEditable: true,
+    };
+  },
   computed: {
     systems() {
       let systemData = this.$store.getters['system/systems'][0];
@@ -113,6 +119,21 @@ export default {
         return `global.status.off`;
       }
       return `global.status.${this.serverStatus}`;
+    },
+  },
+  watch: {
+    systems: function (value) {
+      if (value.lampTest) {
+        this.isLampTestEditable = false;
+        setTimeout(() => {
+          this.isLampTestEditable = true;
+        }, 240000);
+      }
+    },
+    isLampTestEditable: function (value) {
+      if (value) {
+        this.$store.dispatch('system/getSystem');
+      }
     },
   },
   created() {
@@ -137,7 +158,13 @@ export default {
     toggleLampTestSwitch(lampTestState) {
       this.$store
         .dispatch('system/changeLampTestState', lampTestState)
-        .then((message) => this.successToast(message))
+        .then((message) => {
+          this.successToast(message);
+          this.isLampTestEditable = false;
+          setTimeout(() => {
+            this.isLampTestEditable = true;
+          }, 240000);
+        })
         .catch(({ message }) => this.errorToast(message));
     },
   },


### PR DESCRIPTION
- Toggle switch is disabled once turned ON for Lamp Test in Inventory and LEDs page.
- Change the success message on turning ON Lamp test.
- BQ defect: https://w3.rchland.ibm.com/projects/bestquest/?defect=SW553276

Signed-off-by: Nikhil Ashoka <a.nikhil@ibm.com>