### PR TITLE
Tab names translated in Inventory page

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -758,6 +758,7 @@
     "false": "False",
     "fans": "Fans",
     "identifyLedInfo": "For parts with no LEDs, the Identify LED toggle switch will only turn on the Enclosure LED",
+    "ioExpansionChassis": "I/O expansion chassis ",
     "pcieSlots": "PCIe slots",
     "pcieTopologyLink": "PCIe hardware topology.",
     "pcieTopologyLinkDescription": "To know more about PCIe slots, visit ",
@@ -766,6 +767,7 @@
     "processorModule": "Processor Module",
     "quicklinkTitle": "Quick links to hardware components",
     "system": "System",
+    "systemChassis": "System chassis",
     "true": "True",
     "enclosures": {
       "title": "I/O enclosures",

--- a/src/views/HardwareStatus/Inventory/Inventory.vue
+++ b/src/views/HardwareStatus/Inventory/Inventory.vue
@@ -16,8 +16,8 @@
               :key="index"
               :title="
                 index === 0
-                  ? 'System chassis'
-                  : 'I/O expansion chassis ' + `${index}`
+                  ? $t('pageInventory.systemChassis')
+                  : $t('pageInventory.ioExpansionChassis') + `${index}`
               "
               @click="currentTabUpdate(index)"
             >

--- a/src/views/HardwareStatus/Inventory/InventoryTablePcieSlots.vue
+++ b/src/views/HardwareStatus/Inventory/InventoryTablePcieSlots.vue
@@ -124,7 +124,7 @@ export default {
         },
         {
           key: 'type',
-          label: 'Slot type',
+          label: this.$t('pageInventory.table.slotType'),
           formatter: this.dataFormatter,
           sortable: true,
         },


### PR DESCRIPTION
- Tab names were taken only in English, Hence added these names in the translation file.
- Slot type is now taken from the translation file in the PCIe slots table in Inventory page.

Signed-off-by: Nikhil Ashoka <a.nikhil@ibm.com>