### PR TITLE
Using privilege values from the translation file

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -1589,6 +1589,7 @@
       "administrator": "Administrator",
       "privilege": "Privilege",
       "readOnly": "Read only",
+      "serviceAgent": "Service agent",
       "status": "Status",
       "username": "Username"
     },

--- a/src/views/SecurityAndAccess/UserManagement/UserManagement.vue
+++ b/src/views/SecurityAndAccess/UserManagement/UserManagement.vue
@@ -224,7 +224,14 @@ export default {
       return this.allUsers.map((user) => {
         return {
           username: user.UserName,
-          privilege: user.Description,
+          privilege:
+            user.Description === 'Administrator'
+              ? this.$t('pageUserManagement.table.administrator')
+              : user.Description === 'ReadOnly'
+              ? this.$t('pageUserManagement.table.readOnly')
+              : user.Description === 'ServiceAgent'
+              ? this.$t('pageUserManagement.table.serviceAgent')
+              : user.Description,
           status: user.Locked
             ? this.$t('global.status.locked')
             : user.Enabled


### PR DESCRIPTION
- Previously the values were taken from the redfish response, Now we are comparing the value coming from the redfish and then using the equivalent value from the translation file for privilege property in the User management page.

Signed-off-by: Nikhil Ashoka <a.nikhil@ibm.com>