### PR TITLE
SW558381: Revert "Refresh only once after login (#42)"

### DIFF
--- a/src/views/Login/Login.vue
+++ b/src/views/Login/Login.vue
@@ -193,7 +193,8 @@ export default {
               this.$store.dispatch('global/getCurrentUser', username),
               this.$store.dispatch('global/getSystemInfo'),
             ]).then(() => {
-              location.href = '/';
+              this.$router.push('/');
+              location.reload();
             });
           }
         })


### PR DESCRIPTION
This reverts commit 5105bc3af9867dc8c8b2f7747c8b902bb4e7c367.
This revert fixes https://w3.rchland.ibm.com/projects/bestquest/?defect=SW558381

https://github.com/ibm-openbmc/webui-vue/pull/42 was a fix for GUI refreshing twice (https://w3.rchland.ibm.com/projects/bestquest/?defect=SW557765) 
The fix broke the HMC proxy to the GUI. This was reported only breaking on 1030 and in the last month. 

The HMC proxy is accessible via "Connections and operations" -> "Launch Advanced System Management (ASM)". 
https://github.ibm.com/openbmc/webui-vue/pull/208
https://github.ibm.com/openbmc/webui-vue/pull/226
were the original comments to enable the proxy 

With this revert we should reopen https://w3.rchland.ibm.com/projects/bestquest/?defect=SW557765 but I think SW557765 is a lot less worse than SW558381 ( a cosmetic change vs function regression) 

See slack channel #sw558381-debug for more info

Tested: loaded an image with change and the latest 1030 on a system and used the HMC proxy 