### PR TITLE
Fix reset password error prompt password error

### DIFF
--- a/src/views/ChangePassword/ChangePassword.vue
+++ b/src/views/ChangePassword/ChangePassword.vue
@@ -123,12 +123,15 @@ export default {
         password: this.form.password,
       };
 
-      Promise.all([
-        this.$store.dispatch('userManagement/updateUser', data),
-        this.$store.dispatch('userManagement/getUsers'),
-        this.$store.dispatch('global/getCurrentUser', this.username),
-        this.$store.dispatch('global/getSystemInfo'),
-      ])
+      this.$store
+        .dispatch('userManagement/updateUser', data)
+        .then(() => {
+          return Promise.all([
+            this.$store.dispatch('userManagement/getUsers'),
+            this.$store.dispatch('global/getCurrentUser', this.username),
+            this.$store.dispatch('global/getSystemInfo'),
+          ]);
+        })
         .then(() => this.$router.push('/'))
         .catch(() => (this.changePasswordError = true));
     },


### PR DESCRIPTION
After executing a factory reset, reset the password. Even if the entered password meets the requirements of the password complexity, it will prompt that the password is wrong, and then click the reset button again, and it will be successful.

Cause of the problem: When the password is reset, the UI will send the patch and get methods synchronously. Even if the patch method is not completed, the get method will be executed, and 403 will be returned at this time.

So the patch method should be executed first, and the get method should be executed after waiting for the correct return value.

Tested:
After factory reset, reset the password. After entering the correct password, click the reset button, and it will prompt that the reset is successful.

Signed-off-by: George Liu <liuxiwei@inspur.com>