### PR TITLE
Labels now updating in Concurrent maintenance page

### DIFF
--- a/src/store/modules/HardwareStatus/ConcurrentMaintenanceStore.js
+++ b/src/store/modules/HardwareStatus/ConcurrentMaintenanceStore.js
@@ -110,7 +110,7 @@ const ConcurrentMaintenanceStore = {
         });
     },
     async saveReadyToRemoveOpPanelBase({ commit, state }, updatedOpPanelBase) {
-      commit('setReadyToRemoveOpPanel', updatedOpPanelBase);
+      commit('setReadyToRemoveOpPanelBase', updatedOpPanelBase);
       return await api
         .patch('/redfish/v1/Chassis/chassis/Assembly', {
           Assemblies: [
@@ -134,7 +134,7 @@ const ConcurrentMaintenanceStore = {
         })
         .catch((error) => {
           console.log(error);
-          commit('setReadyToRemoveOpPanel', !updatedOpPanelBase);
+          commit('setReadyToRemoveOpPanelBase', !updatedOpPanelBase);
           throw new Error(
             i18n.t('pageConcurrentMaintenance.toast.errorSaveReadyToRemove', {
               state: updatedOpPanelBase ? 'enabling' : 'disabling',
@@ -143,7 +143,7 @@ const ConcurrentMaintenanceStore = {
         });
     },
     async saveReadyToRemoveOpPanelLcd({ commit, state }, updatedOpPanelLcd) {
-      commit('setReadyToRemoveOpPanel', updatedOpPanelLcd);
+      commit('setReadyToRemoveOpPanelLcd', updatedOpPanelLcd);
       return await api
         .patch('/redfish/v1/Chassis/chassis/Assembly', {
           Assemblies: [
@@ -167,7 +167,7 @@ const ConcurrentMaintenanceStore = {
         })
         .catch((error) => {
           console.log(error);
-          commit('setReadyToRemoveOpPanel', !updatedOpPanelLcd);
+          commit('setReadyToRemoveOpPanelLcd', !updatedOpPanelLcd);
           throw new Error(
             i18n.t('pageConcurrentMaintenance.toast.errorSaveReadyToRemove', {
               state: updatedOpPanelLcd ? 'enabling' : 'disabling',


### PR DESCRIPTION
- The values was not updating for Operator panel base maintenance and Operator panel LCD maintenance. The values in the label was not updating as per the values in the switch. It is fixed here.

BQ link:  https://w3.rchland.ibm.com/projects/bestquest/?defect=PE00F0NL

Signed-off-by: Nikhil Ashoka <a.nikhil@ibm.com>