### PR TITLE
Tabs' text color style updated

### DIFF
--- a/src/views/HardwareStatus/Inventory/Inventory.vue
+++ b/src/views/HardwareStatus/Inventory/Inventory.vue
@@ -10,7 +10,7 @@
     <b-row>
       <b-col>
         <b-card no-body>
-          <b-tabs content-class="mt-3" fill>
+          <b-tabs content-class="mt-3" active-nav-item-class="text-dark" fill>
             <b-tab
               v-for="(value, index) in chassis"
               :key="index"

--- a/src/views/Settings/HardwareDeconfiguration/HardwareDeconfiguration.vue
+++ b/src/views/Settings/HardwareDeconfiguration/HardwareDeconfiguration.vue
@@ -18,7 +18,7 @@
       <b-row>
         <b-col>
           <b-card no-body>
-            <b-tabs content-class="mt-3" fill>
+            <b-tabs content-class="mt-3" active-nav-item-class="text-dark" fill>
               <b-tab :title="$t('pageDeconfigurationHardware.memoryDimms')">
                 <memory-dimms />
               </b-tab>

--- a/src/views/Settings/Network/Network.vue
+++ b/src/views/Settings/Network/Network.vue
@@ -8,7 +8,7 @@
       <b-row>
         <b-col>
           <b-card no-body>
-            <b-tabs content-class="mt-3 p-4">
+            <b-tabs content-class="mt-3 p-4" active-nav-item-class="text-dark">
               <b-tab
                 v-for="(data, index) in network"
                 :key="data.id"


### PR DESCRIPTION
- Tabs' text were light grey and were looking as if it i disabled. Now changed the Active tabs' text to be black.

Signed-off-by: Nikhil Ashoka <a.nikhil@ibm.com>