### PR TITLE
Add timeout mechanism when setting Server power policy

### DIFF
--- a/src/store/modules/Operations/BootSettingsStore.js
+++ b/src/store/modules/Operations/BootSettingsStore.js
@@ -183,7 +183,9 @@ const BootSettingsStore = {
           },
         })
         .then((response) => {
-          dispatch('getBiosAttributes');
+          setTimeout(() => {
+            dispatch('getBiosAttributes');
+          }, 2000);
           return response;
         })
         .catch((error) => {


### PR DESCRIPTION
When setting the Server power policy through the GUI, because there is a delay in updating the DBus, it cannot return immediately, and the GUI will immediately obtain the property value through the Get method after setting, resulting in the obtained value is not the updated value, resulting in The radio is not updated. Add a delay of 2s to solve this problem.

Signed-off-by: George Liu <liuxiwei@inspur.com>