### PR TITLE
Filter redundant licenses entry

### DIFF
--- a/src/store/modules/ResourceManagement/LicenseStore.js
+++ b/src/store/modules/ResourceManagement/LicenseStore.js
@@ -37,7 +37,12 @@ const LicenseStore = {
           license.Name !== 'Permanent Processor Licenses' &&
           license.Name !== 'Firmware Update Access Key' &&
           license.Name !== 'Virtualization Engine Technology' &&
-          license.Name !== 'Trial Processor Licenses'
+          license.Name !== 'Trial Processor Licenses' &&
+          license.Name !== 'P05 Virtual Tier' &&
+          license.Name !== 'P10 Virtual Tier' &&
+          license.Name !== 'P20 Virtual Tier' &&
+          license.Name !== 'P30 Virtual Tier' &&
+          license.Name !== 'System Anchor'
         );
       }),
     processorInfo: (state) => parseData(state.licenses.PermProcs),


### PR DESCRIPTION
Because compared with the current Host Fw and the 079 Host Fw, after the host is turned on, there are 5 more licenses entries [1], and all licenses entries are hard-coded in webui-vue, so these 5 entries are temporarily filtered here Data to prevent GUI interface from displaying abnormally.

[1]
P05 Virtual Tier
P10 Virtual Tier
P20 Virtual Tier
P30 Virtual Tier
System Anchor

Signed-off-by: George Liu <liuxiwei@inspur.com>