### PR TITLE
Save button moved above helptext

### DIFF
--- a/src/views/Operations/ServerPowerOperations/BiosSettings.vue
+++ b/src/views/Operations/ServerPowerOperations/BiosSettings.vue
@@ -203,6 +203,9 @@
         </b-col>
       </template>
     </b-row>
+    <b-button variant="primary" type="submit" class="mb-3">
+      {{ $t('global.action.save') }}
+    </b-button>
     <b-row class="mb-3">
       <b-col xl="10">
         <b-button v-b-toggle.collapse-role-table variant="link">

--- a/src/views/Operations/ServerPowerOperations/BootSettings.vue
+++ b/src/views/Operations/ServerPowerOperations/BootSettings.vue
@@ -6,9 +6,6 @@
       :attribute-values="form.attributeValues"
       @updated-attributes="updateAttributeKeys"
     />
-    <b-button variant="primary" type="submit" class="mb-3">
-      {{ $t('global.action.save') }}
-    </b-button>
   </b-form>
 </template>
 <script>


### PR DESCRIPTION
- In the Server power operations page, the save button was below the helptext dropdown. when expanded, the save button moves downwards. This is fixed here.

Signed-off-by: Nikhil Ashoka <a.nikhil@ibm.com>