### PR TITLE
Fabric Adapters showing right info in the respective tabs

### DIFF
--- a/src/store/modules/HardwareStatus/AssemblyStore.js
+++ b/src/store/modules/HardwareStatus/AssemblyStore.js
@@ -41,6 +41,7 @@ const AssemblyStore = {
   },
   actions: {
     async getAssemblyInfo({ commit }, requestBody) {
+      commit('setAssemblyInfo', []);
       return await api
         .get(`${requestBody.uri}/Assembly`)
         .then(({ data }) => commit('setAssemblyInfo', data?.Assemblies))

--- a/src/store/modules/HardwareStatus/FabricAdaptersStore.js
+++ b/src/store/modules/HardwareStatus/FabricAdaptersStore.js
@@ -42,6 +42,7 @@ const FabricAdaptersStore = {
   actions: {
     async getFabricAdaptersInfo({ commit }, requestBody) {
       let tempFabricAdapters = [];
+      commit('setFabricAdaptersInfo', tempFabricAdapters);
       const res = await api.get(requestBody.uri + '/PCIeSlots');
       return await api
         .get(`/redfish/v1/Systems/system/FabricAdapters`)

--- a/src/store/modules/HardwareStatus/FanStore.js
+++ b/src/store/modules/HardwareStatus/FanStore.js
@@ -41,6 +41,7 @@ const FanStore = {
   },
   actions: {
     async getAllFans({ commit }, requestBody) {
+      commit('setFanInfo', []);
       return await api
         .get(`${requestBody.uri}`)
         .then((response) =>

--- a/src/store/modules/HardwareStatus/MemoryStore.js
+++ b/src/store/modules/HardwareStatus/MemoryStore.js
@@ -43,6 +43,7 @@ const MemoryStore = {
   },
   actions: {
     async getDimms({ commit }) {
+      commit('setMemoryInfo', []);
       return await api
         .get('/redfish/v1/Systems/system/Memory')
         .then(({ data: { Members } }) => {

--- a/src/store/modules/HardwareStatus/PcieSlotsStore.js
+++ b/src/store/modules/HardwareStatus/PcieSlotsStore.js
@@ -23,6 +23,7 @@ const PcieSlotsStore = {
   },
   actions: {
     async getPcieSlotsInfo({ commit }, requestBody) {
+      commit('setPcieSlotsInfo', []);
       return await api
         .get(`${requestBody.uri}/PCIeSlots`)
         .then(({ data }) => {

--- a/src/store/modules/HardwareStatus/PowerSupplyStore.js
+++ b/src/store/modules/HardwareStatus/PowerSupplyStore.js
@@ -43,6 +43,7 @@ const PowerSupplyStore = {
   },
   actions: {
     async getAllPowerSupplies({ commit }, requestBody) {
+      commit('setPowerSupply', []);
       return await api
         .get(`${requestBody.uri}`)
         .then((response) => api.get(response.data.PowerSubsystem['@odata.id']))

--- a/src/store/modules/HardwareStatus/ProcessorStore.js
+++ b/src/store/modules/HardwareStatus/ProcessorStore.js
@@ -45,6 +45,7 @@ const ProcessorStore = {
   },
   actions: {
     async getProcessorsInfo({ commit }) {
+      commit('setProcessorsInfo', []);
       return await api
         .get('/redfish/v1/Systems/system/Processors')
         .then(({ data: { Members = [] } }) =>

--- a/src/views/HardwareStatus/Inventory/Inventory.vue
+++ b/src/views/HardwareStatus/Inventory/Inventory.vue
@@ -19,6 +19,7 @@
                   ? $t('pageInventory.systemChassis')
                   : $t('pageInventory.ioExpansionChassis') + `${index}`
               "
+              :disabled="index !== currentTab && isBusy"
               @click="currentTabUpdate(index)"
             >
               <b-container fluid="xl">
@@ -207,6 +208,7 @@ export default {
   },
   data() {
     return {
+      isBusy: false,
       currentTab: 0,
       links: [
         {
@@ -311,65 +313,107 @@ export default {
       return this.$store.getters['chassis/chassis'];
     },
   },
+  watch: {
+    currentTab: function () {
+      this.getAllInfo('watched');
+    },
+  },
   created() {
-    this.startLoader();
-    this.$store.dispatch('chassis/getChassisInfo');
-    const bmcManagerTablePromise = new Promise((resolve) => {
-      this.$root.$on('hardware-status-bmc-manager-complete', () => resolve());
-    });
-    const chassisTablePromise = new Promise((resolve) => {
-      this.$root.$on('hardware-status-chassis-complete', () => resolve());
-    });
-    const dimmSlotTablePromise = new Promise((resolve) => {
-      this.$root.$on('hardware-status-dimm-slot-complete', () => resolve());
-    });
-    const fansTablePromise = new Promise((resolve) => {
-      this.$root.$on('hardware-status-fans-complete', () => resolve());
-    });
-    const powerSuppliesTablePromise = new Promise((resolve) => {
-      this.$root.$on('hardware-status-power-supplies-complete', () =>
-        resolve()
-      );
-    });
-    const processorsTablePromise = new Promise((resolve) => {
-      this.$root.$on('hardware-status-processors-complete', () => resolve());
-    });
-    const serviceIndicatorPromise = new Promise((resolve) => {
-      this.$root.$on('hardware-status-service-complete', () => resolve());
-    });
-    const systemTablePromise = new Promise((resolve) => {
-      this.$root.$on('hardware-status-system-complete', () => resolve());
-    });
-    const assemblyTablePromise = new Promise((resolve) => {
-      this.$root.$on('hardware-status-assembly-complete', () => resolve());
-    });
-    const pcieSlotsTablePromise = new Promise((resolve) => {
-      this.$root.$on('hardware-status-pcie-slots-complete', () => resolve());
-    });
-    const fabricAdaptersTablePromise = new Promise((resolve) => {
-      this.$root.$on('hardware-status-fabric-adapters-complete', () =>
-        resolve()
-      );
-    });
-    // Combine all child component Promises to indicate
-    // when page data load complete
-    Promise.all([
-      bmcManagerTablePromise,
-      chassisTablePromise,
-      dimmSlotTablePromise,
-      fansTablePromise,
-      powerSuppliesTablePromise,
-      processorsTablePromise,
-      serviceIndicatorPromise,
-      systemTablePromise,
-      assemblyTablePromise,
-      pcieSlotsTablePromise,
-      fabricAdaptersTablePromise,
-    ]).finally(() => this.endLoader());
+    this.getAllInfo('created');
   },
   methods: {
     currentTabUpdate(index) {
       this.currentTab = index;
+    },
+    getAllInfo(value) {
+      this.startLoader();
+      this.isBusy = true;
+      this.$store.dispatch('chassis/getChassisInfo');
+      const bmcManagerTablePromise = new Promise((resolve) => {
+        this.$root.$on('hardware-status-bmc-manager-complete', () => resolve());
+      });
+      const chassisTablePromise = new Promise((resolve) => {
+        this.$root.$on('hardware-status-chassis-complete', () => resolve());
+      });
+      const dimmSlotTablePromise = new Promise((resolve) => {
+        this.$root.$on('hardware-status-dimm-slot-complete', () => resolve());
+      });
+      const fansTablePromise = new Promise((resolve) => {
+        this.$root.$on('hardware-status-fans-complete', () => resolve());
+      });
+      const powerSuppliesTablePromise = new Promise((resolve) => {
+        this.$root.$on('hardware-status-power-supplies-complete', () =>
+          resolve()
+        );
+      });
+      const processorsTablePromise = new Promise((resolve) => {
+        this.$root.$on('hardware-status-processors-complete', () => resolve());
+      });
+      const serviceIndicatorPromise = new Promise((resolve) => {
+        this.$root.$on('hardware-status-service-complete', () => resolve());
+      });
+      const systemTablePromise = new Promise((resolve) => {
+        this.$root.$on('hardware-status-system-complete', () => resolve());
+      });
+      const assemblyTablePromise = new Promise((resolve) => {
+        this.$root.$on('hardware-status-assembly-complete', () => resolve());
+      });
+      const pcieSlotsTablePromise = new Promise((resolve) => {
+        this.$root.$on('hardware-status-pcie-slots-complete', () => resolve());
+      });
+      const fabricAdaptersTablePromise = new Promise((resolve) => {
+        this.$root.$on('hardware-status-fabric-adapters-complete', () =>
+          resolve()
+        );
+      });
+      if (this.currentTab === 0 && value === 'created') {
+        // Combine all child component Promises to indicate
+        // when page data load complete
+        Promise.all([
+          bmcManagerTablePromise,
+          chassisTablePromise,
+          dimmSlotTablePromise,
+          fansTablePromise,
+          powerSuppliesTablePromise,
+          processorsTablePromise,
+          serviceIndicatorPromise,
+          systemTablePromise,
+          assemblyTablePromise,
+          pcieSlotsTablePromise,
+          fabricAdaptersTablePromise,
+        ]).finally(() => {
+          this.endLoader();
+          this.isBusy = false;
+        });
+      } else if (this.currentTab === 0 && value === 'watched') {
+        // Combine all child component Promises to indicate
+        // when page data load complete
+        Promise.all([
+          bmcManagerTablePromise,
+          dimmSlotTablePromise,
+          fansTablePromise,
+          powerSuppliesTablePromise,
+          processorsTablePromise,
+          systemTablePromise,
+          assemblyTablePromise,
+          pcieSlotsTablePromise,
+          fabricAdaptersTablePromise,
+        ]).finally(() => {
+          this.endLoader();
+          this.isBusy = false;
+        });
+      } else {
+        Promise.all([
+          fansTablePromise,
+          powerSuppliesTablePromise,
+          assemblyTablePromise,
+          pcieSlotsTablePromise,
+          fabricAdaptersTablePromise,
+        ]).finally(() => {
+          this.endLoader();
+          this.isBusy = false;
+        });
+      }
     },
   },
 };


### PR DESCRIPTION
- Fabric adapters were showing incorrect information when we switch between the tabs. It is fixed here.
- Similar change is made to rest of the tables in the Inventory and LEDs page.
- Progress bar is added for the switching between the tabs.
- BQ defect: https://w3.rchland.ibm.com/projects/bestquest/?defect=PE00F3H9
-https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=390640

Signed-off-by: Nikhil Ashoka <a.nikhil@ibm.com>