### PR TITLE
Fix network page modal issue

### DIFF
--- a/src/views/Settings/Network/ModalIpv4.vue
+++ b/src/views/Settings/Network/ModalIpv4.vue
@@ -172,6 +172,8 @@ export default {
     },
     resetForm() {
       this.form.gateway = this.defaultGateway;
+      this.form.ipAddress = '';
+      this.form.subnetMask = '';
       const item = {
         Address: '',
         SubnetMask: '',


### PR DESCRIPTION
Fix network page modal issue. 

Post setting Network details (IP address, Subnet mask) were not getting cleared. Fixed the issue in resetForm function.

BQ defect : https://w3.rchland.ibm.com/projects/bestquest/?defect=SW559144
https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=392131