### PR TITLE
Fix server firmware start policy

### DIFF
--- a/src/views/Operations/ServerPowerOperations/BiosSettings.vue
+++ b/src/views/Operations/ServerPowerOperations/BiosSettings.vue
@@ -464,7 +464,11 @@ export default {
   methods: {
     hmcManagedChecks(value) {
       if (!this.isHmcManaged()) return true;
-      if (value === 'Server firmware start policy') return true;
+      if (
+        value ===
+        this.$t('pageServerPowerOperations.biosSettings.pvm_stop_at_standby')
+      )
+        return true;
       return false;
     },
     isHmcManaged() {


### PR DESCRIPTION
After switching to a non-English language and bmc is taken over by HMC, `Server firmware start policy` will not be displayed, because it is hard-code, so only English is supported.

This commit is to use a variable to filter `Server firmware start policy` instead of hardcoding.

Tested: Manually changed to non-English, built webui-vue successfully and passes.

Signed-off-by: George Liu <liuxiwei@inspur.com>