### PR TITLE
Add warning message to date time page

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -352,7 +352,8 @@
       "link": "Profile Settings",
       "message": "To change how date and time are displayed (either UTC or browser offset) throughout the application, visit ",
       "messageText": "To change how date and time are displayed (either UTC or browser offset) throughout the application, visit Profile Settings",
-      "messageNtp": "If NTP is selected but an NTP server is not given or the given NTP server is not reachable, then time.google.com will be used."
+      "messageNtp": "If NTP is selected but an NTP server is not given or the given NTP server is not reachable, then time.google.com will be used.",
+      "messagePowerOff": "The server must be powered off to change date and time to manual or NTP."
     },
     "configureSettings": "Configure settings",
     "form": {

--- a/src/views/Settings/DateTime/DateTime.vue
+++ b/src/views/Settings/DateTime/DateTime.vue
@@ -34,7 +34,7 @@
     <page-section :section-title="$t('pageDateTime.configureSettings')">
       <b-row>
         <b-col md="8" xl="6">
-          <alert variant="warning" class="mb-4">
+          <alert v-if="!isServerOff()" variant="warning" class="mb-4">
             <span>
               {{ $t('pageDateTime.alert.messagePowerOff') }}
             </span>

--- a/src/views/Settings/DateTime/DateTime.vue
+++ b/src/views/Settings/DateTime/DateTime.vue
@@ -34,6 +34,11 @@
     <page-section :section-title="$t('pageDateTime.configureSettings')">
       <b-row>
         <b-col md="8" xl="6">
+          <alert variant="warning" class="mb-4">
+            <span>
+              {{ $t('pageDateTime.alert.messagePowerOff') }}
+            </span>
+          </alert>
           <alert variant="info" class="mb-4">
             <span>
               {{ $t('pageDateTime.alert.messageNtp') }}


### PR DESCRIPTION
The date time page is disabled when the server is powered on. Added a warning message for the same.

Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=397294

Signed-off-by: Sandeepa Singh [sandeepa.singh@ibm.com](mailto:sandeepa.singh@ibm.com)