### PR TITLE
Fixed Health and Status values for I/O expansion chassis

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -85,6 +85,7 @@
       "on": "On",
       "present": "Present",
       "success": "Success",
+      "unavailable": "Unavailable",
       "warning": "Warning"
     },
     "table": {
@@ -787,6 +788,7 @@
     "alert": {
       "enclosureAlertTitle": "Viewing enclosure configuration",
       "enclosureAlertMessage": "System needs to be powered on.",
+      "powerOffExpansionChassis": "Health and status values in I/O expansion chassis are unavailable when the host is powered off.",
       "viewServerPowerOperations": "View server power operations"
     },
     "modal": {

--- a/src/views/HardwareStatus/Inventory/Inventory.vue
+++ b/src/views/HardwareStatus/Inventory/Inventory.vue
@@ -120,6 +120,15 @@
                 />
 
                 <!-- Mex Chassis -->
+                <alert
+                  v-if="currentTab > 0 && isPoweredOff"
+                  variant="info"
+                  class="mb-4"
+                >
+                  <span>
+                    {{ $t('pageInventory.alert.powerOffExpansionChassis') }}
+                  </span>
+                </alert>
                 <!-- Fans table -->
                 <table-fans
                   v-if="currentTab > 0"
@@ -164,6 +173,7 @@
 </template>
 
 <script>
+import Alert from '@/components/Global/Alert';
 import PageTitle from '@/components/Global/PageTitle';
 import TableSystem from './InventoryTableSystem';
 import TablePowerSupplies from './InventoryTablePowerSupplies';
@@ -184,6 +194,7 @@ import { chunk } from 'lodash';
 
 export default {
   components: {
+    Alert,
     PageTitle,
     ServiceIndicator,
     TableDimmSlot,
@@ -311,6 +322,13 @@ export default {
     },
     chassis() {
       return this.$store.getters['chassis/chassis'];
+    },
+    isPoweredOff() {
+      if (this.$store.getters['global/serverStatus'] === 'off') {
+        return true;
+      } else {
+        return false;
+      }
     },
   },
   watch: {

--- a/src/views/HardwareStatus/Inventory/InventoryFabricAdapters.vue
+++ b/src/views/HardwareStatus/Inventory/InventoryFabricAdapters.vue
@@ -47,9 +47,15 @@
       </template>
       <!-- Health -->
       <template #cell(health)="{ value }">
-        <status-icon :status="statusIcon(value)" />
+        <status-icon
+          v-if="isIoExpansionChassis && isPoweredOff"
+          :status="statusIcon('')"
+        />
+        <status-icon v-else :status="statusIcon(value)" />
         {{
-          value === 'OK'
+          isIoExpansionChassis && isPoweredOff
+            ? $t('global.status.unavailable')
+            : value === 'OK'
             ? $t('global.status.ok')
             : value === 'Warning'
             ? $t('global.status.warning')
@@ -59,7 +65,9 @@
       <!-- Status -->
       <template #cell(status)="row">
         {{
-          row.item.status === 'Absent'
+          isIoExpansionChassis && isPoweredOff
+            ? $t('global.status.unavailable')
+            : row.item.status === 'Absent'
             ? $t('global.status.absent')
             : $t('global.status.present')
         }}
@@ -71,6 +79,7 @@
           v-model="row.item.identifyLed"
           name="switch"
           switch
+          :disabled="serverStatus"
           @change="toggleIdentifyLedValue(row.item)"
         >
           <span v-if="row.item.identifyLed">
@@ -198,6 +207,29 @@ export default {
     fabricAdapters() {
       const adapters = this.$store.getters['fabricAdapters/fabricAdapters'];
       return adapters;
+    },
+    serverStatus() {
+      if (this.chassis.endsWith('chassis')) {
+        return false;
+      } else if (this.$store.getters['global/serverStatus'] !== 'on') {
+        return true;
+      } else {
+        return false;
+      }
+    },
+    isPoweredOff() {
+      if (this.$store.getters['global/serverStatus'] === 'off') {
+        return true;
+      } else {
+        return false;
+      }
+    },
+    isIoExpansionChassis() {
+      if (this.chassis.endsWith('chassis')) {
+        return false;
+      } else {
+        return true;
+      }
     },
   },
   watch: {

--- a/src/views/HardwareStatus/Inventory/InventoryTableAssembly.vue
+++ b/src/views/HardwareStatus/Inventory/InventoryTableAssembly.vue
@@ -49,9 +49,15 @@
       </template>
       <!-- Health -->
       <template #cell(health)="row">
-        <status-icon :status="statusIcon(row.item.health)" />
+        <status-icon
+          v-if="isIoExpansionChassis && isPoweredOff"
+          :status="statusIcon('')"
+        />
+        <status-icon v-else :status="statusIcon(row.item.health)" />
         {{
-          row.item.health === 'OK'
+          isIoExpansionChassis && isPoweredOff
+            ? $t('global.status.unavailable')
+            : row.item.health === 'OK'
             ? $t('global.status.ok')
             : row.item.health === 'Warning'
             ? $t('global.status.warning')
@@ -61,7 +67,9 @@
       <!-- Status -->
       <template #cell(status)="row">
         {{
-          row.item.status === 'Enabled'
+          isIoExpansionChassis && isPoweredOff
+            ? $t('global.status.unavailable')
+            : row.item.status === 'Enabled'
             ? $t('global.status.present')
             : $t('global.status.absent')
         }}
@@ -213,6 +221,13 @@ export default {
       if (this.chassis.endsWith('chassis')) {
         return false;
       } else if (this.$store.getters['global/serverStatus'] !== 'on') {
+        return true;
+      } else {
+        return false;
+      }
+    },
+    isPoweredOff() {
+      if (this.$store.getters['global/serverStatus'] === 'off') {
         return true;
       } else {
         return false;

--- a/src/views/HardwareStatus/Inventory/InventoryTableFans.vue
+++ b/src/views/HardwareStatus/Inventory/InventoryTableFans.vue
@@ -50,9 +50,15 @@
       </template>
       <!-- Health -->
       <template #cell(health)="{ value }">
-        <status-icon :status="statusIcon(value)" />
+        <status-icon
+          v-if="isIoExpansionChassis && isPoweredOff"
+          :status="statusIcon('')"
+        />
+        <status-icon v-else :status="statusIcon(value)" />
         {{
-          value === 'OK'
+          isIoExpansionChassis && isPoweredOff
+            ? $t('global.status.unavailable')
+            : value === 'OK'
             ? $t('global.status.ok')
             : value === 'Warning'
             ? $t('global.status.warning')
@@ -63,7 +69,9 @@
       <!-- Status -->
       <template #cell(status)="row">
         {{
-          row.item.status === 'Enabled'
+          isIoExpansionChassis && isPoweredOff
+            ? $t('global.status.unavailable')
+            : row.item.status === 'Enabled'
             ? $t('global.status.present')
             : $t('global.status.absent')
         }}
@@ -216,6 +224,13 @@ export default {
       if (this.chassis.endsWith('chassis')) {
         return false;
       } else if (this.$store.getters['global/serverStatus'] !== 'on') {
+        return true;
+      } else {
+        return false;
+      }
+    },
+    isPoweredOff() {
+      if (this.$store.getters['global/serverStatus'] === 'off') {
         return true;
       } else {
         return false;

--- a/src/views/HardwareStatus/Inventory/InventoryTablePowerSupplies.vue
+++ b/src/views/HardwareStatus/Inventory/InventoryTablePowerSupplies.vue
@@ -47,9 +47,15 @@
 
       <!-- Health -->
       <template #cell(health)="{ value }">
-        <status-icon :status="statusIcon(value)" />
+        <status-icon
+          v-if="isIoExpansionChassis && isPoweredOff"
+          :status="statusIcon('')"
+        />
+        <status-icon v-else :status="statusIcon(value)" />
         {{
-          value === 'OK'
+          isIoExpansionChassis && isPoweredOff
+            ? $t('global.status.unavailable')
+            : value === 'OK'
             ? $t('global.status.ok')
             : value === 'Warning'
             ? $t('global.status.warning')
@@ -59,7 +65,9 @@
       <!-- Status -->
       <template #cell(status)="row">
         {{
-          row.item.status === 'Enabled'
+          isIoExpansionChassis && isPoweredOff
+            ? $t('global.status.unavailable')
+            : row.item.status === 'Enabled'
             ? $t('global.status.present')
             : $t('global.status.absent')
         }}
@@ -215,6 +223,13 @@ export default {
       if (this.chassis.endsWith('chassis')) {
         return false;
       } else if (this.$store.getters['global/serverStatus'] !== 'on') {
+        return true;
+      } else {
+        return false;
+      }
+    },
+    isPoweredOff() {
+      if (this.$store.getters['global/serverStatus'] === 'off') {
         return true;
       } else {
         return false;

--- a/tests/unit/__snapshots__/AppHeader.spec.js.snap
+++ b/tests/unit/__snapshots__/AppHeader.spec.js.snap
@@ -56,7 +56,7 @@ exports[`AppHeader.vue should render correctly 1`] = `
           <img
             alt="Built on OpenBMC"
             class="header-logo"
-            src="http://localhost/img/logo-header.svg"
+            src="http://localhost"
             width="50px"
           />
            


### PR DESCRIPTION
- When System is in power off, Health and Status values for I/O expansion chassis values were inaccurate. Hence, we are displaying as "Unavailable" in this fix.

- Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=412141