### PR TITLE
Logging out after hostname update

### DIFF
--- a/src/views/Settings/Network/Network.vue
+++ b/src/views/Settings/Network/Network.vue
@@ -168,12 +168,7 @@ export default {
       this.startLoader();
       this.$store
         .dispatch('network/saveHostname', modalFormData)
-        .then((message) => this.successToast(message))
-        .then(
-          setTimeout(() => {
-            this.$store.dispatch('authentication/logout');
-          }, 3000 /* 3 seconds */)
-        )
+        .then(this.$store.dispatch('authentication/logout'))
         .catch(({ message }) => this.errorToast(message))
         .finally(() => this.endLoader());
     },


### PR DESCRIPTION
- The expected behaviour was the user to logout after the hostname is updated in the Networks page. This is fixed here. And also, the name is updating.

- Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=402313