### PR TITLE
Changed the default value of Health in Inventory page

### DIFF
--- a/src/views/HardwareStatus/Inventory/InventoryFabricAdapters.vue
+++ b/src/views/HardwareStatus/Inventory/InventoryFabricAdapters.vue
@@ -59,7 +59,9 @@
             ? $t('global.status.ok')
             : value === 'Warning'
             ? $t('global.status.warning')
-            : $t('global.status.critical')
+            : value === 'Critical'
+            ? $t('global.status.critical')
+            : '--'
         }}
       </template>
       <!-- Status -->

--- a/src/views/HardwareStatus/Inventory/InventoryTableAssembly.vue
+++ b/src/views/HardwareStatus/Inventory/InventoryTableAssembly.vue
@@ -61,7 +61,9 @@
             ? $t('global.status.ok')
             : row.item.health === 'Warning'
             ? $t('global.status.warning')
-            : $t('global.status.critical')
+            : row.item.health === 'Critical'
+            ? $t('global.status.critical')
+            : '--'
         }}
       </template>
       <!-- Status -->

--- a/src/views/HardwareStatus/Inventory/InventoryTableBmcManager.vue
+++ b/src/views/HardwareStatus/Inventory/InventoryTableBmcManager.vue
@@ -38,7 +38,9 @@
             ? $t('global.status.ok')
             : value === 'Warning'
             ? $t('global.status.warning')
-            : $t('global.status.critical')
+            : value === 'Critical'
+            ? $t('global.status.critical')
+            : '--'
         }}
       </template>
       <!-- Status -->

--- a/src/views/HardwareStatus/Inventory/InventoryTableChassis.vue
+++ b/src/views/HardwareStatus/Inventory/InventoryTableChassis.vue
@@ -31,7 +31,9 @@
             ? $t('global.status.ok')
             : value === 'Warning'
             ? $t('global.status.warning')
-            : $t('global.status.critical')
+            : value === 'Critical'
+            ? $t('global.status.critical')
+            : '--'
         }}
       </template>
       <!-- Status -->

--- a/src/views/HardwareStatus/Inventory/InventoryTableDimmSlot.vue
+++ b/src/views/HardwareStatus/Inventory/InventoryTableDimmSlot.vue
@@ -53,7 +53,9 @@
             ? $t('global.status.ok')
             : value === 'Warning'
             ? $t('global.status.warning')
-            : $t('global.status.critical')
+            : value === 'Critical'
+            ? $t('global.status.critical')
+            : '--'
         }}
       </template>
       <!-- Status -->

--- a/src/views/HardwareStatus/Inventory/InventoryTableFans.vue
+++ b/src/views/HardwareStatus/Inventory/InventoryTableFans.vue
@@ -62,7 +62,9 @@
             ? $t('global.status.ok')
             : value === 'Warning'
             ? $t('global.status.warning')
-            : $t('global.status.critical')
+            : value === 'Critical'
+            ? $t('global.status.critical')
+            : '--'
         }}
       </template>
 

--- a/src/views/HardwareStatus/Inventory/InventoryTablePowerSupplies.vue
+++ b/src/views/HardwareStatus/Inventory/InventoryTablePowerSupplies.vue
@@ -59,7 +59,9 @@
             ? $t('global.status.ok')
             : value === 'Warning'
             ? $t('global.status.warning')
-            : $t('global.status.critical')
+            : value === 'Critical'
+            ? $t('global.status.critical')
+            : '--'
         }}
       </template>
       <!-- Status -->

--- a/src/views/HardwareStatus/Inventory/InventoryTableProcessors.vue
+++ b/src/views/HardwareStatus/Inventory/InventoryTableProcessors.vue
@@ -52,7 +52,9 @@
             ? $t('global.status.ok')
             : value === 'Warning'
             ? $t('global.status.warning')
-            : $t('global.status.critical')
+            : value === 'Critical'
+            ? $t('global.status.critical')
+            : '--'
         }}
       </template>
       <!-- Status -->

--- a/src/views/HardwareStatus/Inventory/InventoryTableSystem.vue
+++ b/src/views/HardwareStatus/Inventory/InventoryTableSystem.vue
@@ -31,7 +31,9 @@
             ? $t('global.status.ok')
             : value === 'Warning'
             ? $t('global.status.warning')
-            : $t('global.status.critical')
+            : value === 'Critical'
+            ? $t('global.status.critical')
+            : '--'
         }}
       </template>
       <!-- Status -->


### PR DESCRIPTION
- The default value of the health in tables of Inventory page was 'Critical'. That is the reason for the values when unavailable, was displayed as 'Critical'. Now, changed the default value to '--' when none of the other conditions match.
- Also -- is the standard we are using when a value is empty in the GUI.

- Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=479849