### PR TITLE
"Secure LDAP" value is retained

### DIFF
--- a/src/views/HardwareStatus/Inventory/Inventory.vue
+++ b/src/views/HardwareStatus/Inventory/Inventory.vue
@@ -336,6 +336,11 @@ export default {
       this.getAllInfo('watched');
     },
   },
+  watch: {
+    currentTab: function () {
+      this.getAllInfo('watched');
+    },
+  },
   created() {
     this.getAllInfo('created');
   },

--- a/src/views/HardwareStatus/Inventory/Inventory.vue
+++ b/src/views/HardwareStatus/Inventory/Inventory.vue
@@ -336,11 +336,6 @@ export default {
       this.getAllInfo('watched');
     },
   },
-  watch: {
-    currentTab: function () {
-      this.getAllInfo('watched');
-    },
-  },
   created() {
     this.getAllInfo('created');
   },

--- a/src/views/SecurityAndAccess/Ldap/Ldap.vue
+++ b/src/views/SecurityAndAccess/Ldap/Ldap.vue
@@ -315,6 +315,12 @@ export default {
       this.form.activeDirectoryEnabled = value;
       this.setFormValues();
     },
+    caCertificateExpiration: function () {
+      this.setFormValues();
+    },
+    ldapCertificateExpiration: function () {
+      this.setFormValues();
+    },
   },
   validations: {
     form: {


### PR DESCRIPTION
- The value was getting set to disabled by default after the browser 
  is reloaded. It is fixed here.
  
- Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=484470