### PR TITLE
Resource dump is now submitted in any state

### DIFF
--- a/src/views/Logs/Dumps/DumpsForm.vue
+++ b/src/views/Logs/Dumps/DumpsForm.vue
@@ -133,10 +133,6 @@ export default {
     handleSubmit() {
       this.$v.$touch();
       if (this.$v.$invalid) return;
-      if (this.selectedDumpType === 'resource' && !this.isInPhypStandby) {
-        this.errorToast(this.$t('pageDumps.toast.errorPhypInStandby'));
-        return;
-      }
 
       const dumpType = this.$t(`pageDumps.form.${this.selectedDumpType}Dump`);
 


### PR DESCRIPTION
    Resource dump was initially submitted only in phyp in standby. Now, That condition is removed.

    Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=500826