### PR TITLE
Updated the helptext of RTAD

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -1240,7 +1240,7 @@
     "ipmi": "Network IPMI (out-of-band IPMI)",
     "ipmiDescription": "Allow remote management of the platform via IPMI. Tools such as ipmitool require this setting to be enabled. Once enabled, please follow the procedure in the online support documentation to add IPMI users.",
     "rtad": "RTAD",
-    "rtadDescription": "This option enables or disables the Remote Trusted Attestation Daemon for host firmware.",
+    "rtadDescription": "This setting only applies if the Virtualization Management Interface (VMI) is running. The Virtualization Management Interface is running if the system is HMC managed.",
     "rtadInfoIcon": "@:global.status.nextReboot",
     "secureVersion": "Secure version lock-in",
     "secureVersionDescription": "Specifies whether the secure version lock-in functionality is enabled.",

--- a/src/views/HardwareStatus/Inventory/Inventory.vue
+++ b/src/views/HardwareStatus/Inventory/Inventory.vue
@@ -336,6 +336,11 @@ export default {
       this.getAllInfo('watched');
     },
   },
+  watch: {
+    currentTab: function () {
+      this.getAllInfo('watched');
+    },
+  },
   created() {
     this.getAllInfo('created');
   },

--- a/src/views/HardwareStatus/Inventory/Inventory.vue
+++ b/src/views/HardwareStatus/Inventory/Inventory.vue
@@ -336,11 +336,6 @@ export default {
       this.getAllInfo('watched');
     },
   },
-  watch: {
-    currentTab: function () {
-      this.getAllInfo('watched');
-    },
-  },
   created() {
     this.getAllInfo('created');
   },


### PR DESCRIPTION
- The helptext/description of the RTAD in the Policies page is now updated from "This option enables or disables the 
  Remote Trusted Attestation Daemon for host firmware." to "This setting only applies if the Virtualization Management
  Interface (VMI) is running. The Virtualization Management Interface is running if the system is HMC managed."
  
  Story link: https://jsw.ibm.com/browse/PFEBMC-776