### PR TITLE
Dumps initiate fixed

### DIFF
--- a/src/store/modules/Logs/DumpsStore.js
+++ b/src/store/modules/Logs/DumpsStore.js
@@ -59,7 +59,6 @@ const DumpsStore = {
           '/redfish/v1/Managers/bmc/LogServices/Dump/Actions/LogService.CollectDiagnosticData',
           {
             DiagnosticDataType: 'Manager',
-            OEMDiagnosticDataType: '',
           }
         )
         .catch((error) => {

--- a/src/views/HardwareStatus/Inventory/Inventory.vue
+++ b/src/views/HardwareStatus/Inventory/Inventory.vue
@@ -336,6 +336,11 @@ export default {
       this.getAllInfo('watched');
     },
   },
+  watch: {
+    currentTab: function () {
+      this.getAllInfo('watched');
+    },
+  },
   created() {
     this.getAllInfo('created');
   },

--- a/src/views/HardwareStatus/Inventory/Inventory.vue
+++ b/src/views/HardwareStatus/Inventory/Inventory.vue
@@ -336,11 +336,6 @@ export default {
       this.getAllInfo('watched');
     },
   },
-  watch: {
-    currentTab: function () {
-      this.getAllInfo('watched');
-    },
-  },
   created() {
     this.getAllInfo('created');
   },


### PR DESCRIPTION
- The Dumps creation was giving an error. Updated the request body from {DiagnosticDataType: 'Manager', OEMDiagnosticDataType: ''} to {DiagnosticDataType: 'Manager'} in this commit.
- Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=536512