### PR TITLE
Informational logs not shown for the admin

### DIFF
--- a/src/store/modules/Logs/EventLogStore.js
+++ b/src/store/modules/Logs/EventLogStore.js
@@ -43,10 +43,13 @@ const EventLogStore = {
   },
   actions: {
     async getEventLogData({ commit }) {
+      let eventLogs = [];
+      commit('setAllEvents', eventLogs);
+      commit('setCeLogs', eventLogs);
       return await api
         .get('/redfish/v1/Systems/system/LogServices/EventLog/Entries')
         .then(({ data: { Members = [] } = {} }) => {
-          const eventLogs = Members.map((log) => {
+          eventLogs = Members.map((log) => {
             const {
               Id,
               EventId,

--- a/src/views/HardwareStatus/Inventory/Inventory.vue
+++ b/src/views/HardwareStatus/Inventory/Inventory.vue
@@ -336,6 +336,11 @@ export default {
       this.getAllInfo('watched');
     },
   },
+  watch: {
+    currentTab: function () {
+      this.getAllInfo('watched');
+    },
+  },
   created() {
     this.getAllInfo('created');
   },

--- a/src/views/HardwareStatus/Inventory/Inventory.vue
+++ b/src/views/HardwareStatus/Inventory/Inventory.vue
@@ -336,11 +336,6 @@ export default {
       this.getAllInfo('watched');
     },
   },
-  watch: {
-    currentTab: function () {
-      this.getAllInfo('watched');
-    },
-  },
   created() {
     this.getAllInfo('created');
   },


### PR DESCRIPTION
- Once we login with service and access the Event logs page, the correct data is loaded in the table, But after logout and then login back as admin, 
  then when we access Event logs page, the previous data which includes the informational logs were listed. This is fixed here.
- Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=511587