### PR TITLE
Delay to retrieve data when new address is added

### DIFF
--- a/src/store/modules/Settings/NetworkStore.js
+++ b/src/store/modules/Settings/NetworkStore.js
@@ -319,7 +319,11 @@ const NetworkStore = {
           `/redfish/v1/Managers/bmc/EthernetInterfaces/${state.selectedInterfaceId}`,
           updatedIpv4Array
         )
-        .then(dispatch('getEthernetData'))
+        .then(() => {
+          setTimeout(() => {
+            dispatch('getEthernetData');
+          }, 10000);
+        })
         .then(() => {
           return i18n.t('pageNetwork.toast.successSaveNetworkSettings', {
             setting: i18n.t('pageNetwork.ipv4'),

--- a/src/views/HardwareStatus/Inventory/Inventory.vue
+++ b/src/views/HardwareStatus/Inventory/Inventory.vue
@@ -336,6 +336,11 @@ export default {
       this.getAllInfo('watched');
     },
   },
+  watch: {
+    currentTab: function () {
+      this.getAllInfo('watched');
+    },
+  },
   created() {
     this.getAllInfo('created');
   },

--- a/src/views/HardwareStatus/Inventory/Inventory.vue
+++ b/src/views/HardwareStatus/Inventory/Inventory.vue
@@ -336,11 +336,6 @@ export default {
       this.getAllInfo('watched');
     },
   },
-  watch: {
-    currentTab: function () {
-      this.getAllInfo('watched');
-    },
-  },
   created() {
     this.getAllInfo('created');
   },


### PR DESCRIPTION
- When we add a new address, the immediate retrieval of data from redfish creates issues as the order of the contents in the table is not right.
Hence, added a 10 seconds delay so that it waits and then retrieves and displays the contents in right order.
- Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=481243