### PR TITLE
Fixed deconfiguration record header

### DIFF
--- a/src/views/Logs/DeconfigurationRecords/DeconfigurationRecords.vue
+++ b/src/views/Logs/DeconfigurationRecords/DeconfigurationRecords.vue
@@ -1,7 +1,7 @@
 <template>
   <b-container fluid="xl">
     <page-title
-      :title="$t('appPageTitle.deconfigurationHardware')"
+      :title="$t('appPageTitle.deconfigurationRecords')"
       :description="
         $t('pageDeconfigurationRecords.pageDescription.description')
       "

--- a/src/views/Overview/OverviewInventory.vue
+++ b/src/views/Overview/OverviewInventory.vue
@@ -29,12 +29,14 @@
 
 <script>
 import OverviewCard from './OverviewCard';
+import BVToastMixin from '@/components/Mixins/BVToastMixin';
 
 export default {
   name: 'Inventory',
   components: {
     OverviewCard,
   },
+  mixins: [BVToastMixin],
   computed: {
     systems() {
       let systemData = this.$store.getters['system/systems'][0];
@@ -50,6 +52,7 @@ export default {
     toggleIdentifyLedSwitch(state) {
       this.$store
         .dispatch('system/changeIdentifyLedState', state)
+        .then((message) => this.successToast(message))
         .catch(({ message }) => this.errorToast(message));
     },
   },

--- a/src/views/Overview/OverviewInventory.vue
+++ b/src/views/Overview/OverviewInventory.vue
@@ -29,14 +29,12 @@
 
 <script>
 import OverviewCard from './OverviewCard';
-import BVToastMixin from '@/components/Mixins/BVToastMixin';
 
 export default {
   name: 'Inventory',
   components: {
     OverviewCard,
   },
-  mixins: [BVToastMixin],
   computed: {
     systems() {
       let systemData = this.$store.getters['system/systems'][0];
@@ -52,7 +50,6 @@ export default {
     toggleIdentifyLedSwitch(state) {
       this.$store
         .dispatch('system/changeIdentifyLedState', state)
-        .then((message) => this.successToast(message))
         .catch(({ message }) => this.errorToast(message));
     },
   },


### PR DESCRIPTION
Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=545468
Description: once user lands on the Hardware status and navigate to Hardware Deconfiguration page, once we click on 
 Deconfiguration records page, the header is not correct.
Fix Screenshot: 
<img width="959" alt="image" src="https://github.com/ibm-openbmc/webui-vue/assets/110152569/d8cdc76e-531d-48f8-8f4d-3f09fff258e7">


