### PR TITLE
Fix popup-box authenticate on session disconnect

### DIFF
--- a/src/store/api.js
+++ b/src/store/api.js
@@ -5,6 +5,9 @@ import Axios from 'axios';
 import store from '../store';
 import router from '@/router';
 
+Axios.defaults.headers.common['Accept'] = 'application/json';
+Axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
+
 const api = Axios.create({
   baseURL: window.location.origin + window.location.pathname,
   withCredentials: true,


### PR DESCRIPTION
Upstream is merged at https://gerrit.openbmc.org/c/openbmc/webui-vue/+/61961 
Defect is 485017

See https://stackoverflow.com/questions/67353409/suppressing-www-authenticate-using-x-requested-with-xmlhttprequest-source for more information about how this works. 

On the session Web UI page, when we disconnect the current session, instead of navigating to the login page, the browser populates the authentication window for basic authorization.

If basic authentication is enabled, we are adding the www-authenticate header to unauthorizing requests.

As per redfish, we have to set the "Accept" and "X-Requested-With" header for the request from Web UI. This patch set will add those headers.

Tested:

Logged in to the WebUI and navigated to the sessions page. Clicked "Disconnect" to the current session and the WebUI is navigated to login. page as expected.

Change-Id: I61cccbf41e854683e6cd5aa80fa72593ae4aa698