### PR TITLE
Fixed User unable to delete the firmware file if name is long on firmware page

### DIFF
--- a/src/components/Global/FormFile.vue
+++ b/src/components/Global/FormFile.vue
@@ -118,4 +118,7 @@ export default {
     }
   }
 }
+.custom-form-file-container {
+  word-break: break-all;
+}
 </style>

--- a/src/components/Global/FormFile.vue
+++ b/src/components/Global/FormFile.vue
@@ -105,6 +105,8 @@ export default {
   display: flex;
   align-items: center;
   background-color: theme-color('light');
+  position: relative;
+  z-index: 2;
   .btn {
     width: 36px;
     height: 36px;


### PR DESCRIPTION
Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=546451
Description: Once user lands on the Operations -> Firmware Page, then click on Add file button. Select the firmware.
Post this user will not able to delete , as close icon does not work. Now able to achieve this 

Fix Screenshot:
<img width="694" alt="image" src="https://github.com/ibm-openbmc/webui-vue/assets/110152569/ce14e120-426e-4dff-897c-824d4ebb96b2">

<img width="562" alt="image" src="https://github.com/ibm-openbmc/webui-vue/assets/110152569/a4515b16-94db-4d2c-815a-fbca60c7092a">
