### PR TITLE
Filter values for Sensors and PCIe topology taken from translation file

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -971,6 +971,7 @@
       "ldapSettings": "LDAP settings"
     },
     "form": {
+      "activeDirectory": "Active Directory",
       "baseDn": "Base DN",
       "bindDn": "Bind DN",
       "bindPassword": "Bind password",
@@ -979,6 +980,7 @@
       "ldapAuthentication": "LDAP authentication",
       "ldapCertificateValidUntil": "LDAP Certificate valid until",
       "manageSslCertificates": "Manage SSL certificates",
+      "openLDAP": "OpenLDAP",
       "secureLdapHelper": "A CA certificate and an LDAP certificate are required to enable secure LDAP",
       "secureLdapUsingSsl": "Secure LDAP using SSL",
       "serverUri": "Server URI",
@@ -1218,7 +1220,16 @@
         "resetLinkHeader": "Reset link %{id}"
       },
       "table": {
-        "search": "Search"
+        "search": "Search",
+        "linkStatusType": "Link status type",
+        "filter": {
+          "degraded": "Degraded",
+          "failed": "Failed",
+          "inactive": "Inactive",
+          "open": "Open",
+          "operational": "Operational",
+          "unknown": "Unknown"
+        }
       },
       "toast": {
         "errorReset": "Error resetting link %{id}",
@@ -1412,7 +1423,12 @@
       "name": "Name",
       "status": "Status",
       "upperCritical": "Upper critical",
-      "upperWarning": "Upper warning"
+      "upperWarning": "Upper warning",
+      "filter": {
+        "ok": "OK",
+        "critical": "Critical",
+        "warning": "Warning"
+      }
     }
   },
   "pageServerPowerOperations": {

--- a/src/views/HardwareStatus/Inventory/Inventory.vue
+++ b/src/views/HardwareStatus/Inventory/Inventory.vue
@@ -336,6 +336,11 @@ export default {
       this.getAllInfo('watched');
     },
   },
+  watch: {
+    currentTab: function () {
+      this.getAllInfo('watched');
+    },
+  },
   created() {
     this.getAllInfo('created');
   },

--- a/src/views/HardwareStatus/Inventory/Inventory.vue
+++ b/src/views/HardwareStatus/Inventory/Inventory.vue
@@ -336,11 +336,6 @@ export default {
       this.getAllInfo('watched');
     },
   },
-  watch: {
-    currentTab: function () {
-      this.getAllInfo('watched');
-    },
-  },
   created() {
     this.getAllInfo('created');
   },

--- a/src/views/HardwareStatus/PcieTopology/PcieTopology.vue
+++ b/src/views/HardwareStatus/PcieTopology/PcieTopology.vue
@@ -369,14 +369,14 @@ export default {
       tableFilters: [
         {
           key: 'linkStatus',
-          label: 'Link status type',
+          label: this.$t('pagePcieTopology.table.linkStatusType'),
           values: [
-            'Degraded',
-            'Inactive',
-            'Open',
-            'Operational',
-            'Unknown',
-            'Failed',
+            this.$t('pagePcieTopology.table.filter.degraded'),
+            this.$t('pagePcieTopology.table.filter.inactive'),
+            this.$t('pagePcieTopology.table.filter.open'),
+            this.$t('pagePcieTopology.table.filter.operational'),
+            this.$t('pagePcieTopology.table.filter.unknown'),
+            this.$t('pagePcieTopology.table.filter.failed'),
           ],
         },
       ],

--- a/src/views/HardwareStatus/Sensors/Sensors.vue
+++ b/src/views/HardwareStatus/Sensors/Sensors.vue
@@ -207,7 +207,11 @@ export default {
         {
           key: 'status',
           label: this.$t('pageSensors.table.status'),
-          values: ['OK', 'Warning', 'Critical'],
+          values: [
+            this.$t('pageSensors.table.filter.ok'),
+            this.$t('pageSensors.table.filter.warning'),
+            this.$t('pageSensors.table.filter.critical'),
+          ],
         },
       ],
       activeFilters: [],

--- a/src/views/SecurityAndAccess/Ldap/Ldap.vue
+++ b/src/views/SecurityAndAccess/Ldap/Ldap.vue
@@ -81,7 +81,7 @@
                         :value="false"
                         @change="onChangeServiceType"
                       >
-                        OpenLDAP
+                        {{ $t('pageLdap.form.openLDAP') }}
                       </b-form-radio>
                       <b-form-radio
                         v-model="form.activeDirectoryEnabled"
@@ -89,7 +89,7 @@
                         :value="true"
                         @change="onChangeServiceType"
                       >
-                        Active Directory
+                        {{ $t('pageLdap.form.activeDirectory') }}
                       </b-form-radio>
                     </b-form-group>
                   </b-col>


### PR DESCRIPTION
- The filter values for the Sensors and PCIe topology were not translated, So Now, we are taking these values from the translation file.
- Updated OpenLDAP and Active Directory values in the translation file.

-Defects:
1. Chinese (Traditional) - https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=458832
2. Portuguese and Brazilian portuguese - https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=458735
3. French - https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=458542 
4. German - https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=458471
5. Japanese - https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=454677 
6. Italian - https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=444601
7. Spanish - https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=443988