### PR TITLE
Fixed search functionality for all the fields in Inventory and LED page

### DIFF
--- a/src/store/modules/HardwareStatus/AssemblyStore.js
+++ b/src/store/modules/HardwareStatus/AssemblyStore.js
@@ -33,7 +33,7 @@ const AssemblyStore = {
           name: Name,
           locationNumber: Location?.PartLocation?.ServiceLabel,
           identifyLed: LocationIndicatorActive,
-          status: Status?.State,
+          status: Status?.State === 'Enabled' ? 'Present' : Status?.State,
           uri: assembly['@odata.id'],
         };
       });

--- a/src/store/modules/HardwareStatus/FabricAdaptersStore.js
+++ b/src/store/modules/HardwareStatus/FabricAdaptersStore.js
@@ -33,7 +33,7 @@ const FabricAdaptersStore = {
           partNumber: PartNumber,
           serialNumber: SerialNumber,
           sparePartNumber: SparePartNumber,
-          status: Status?.State,
+          status: Status?.State === 'Enabled' ? 'Present' : Status?.State,
           uri: adapter['@odata.id'],
         };
       });

--- a/src/store/modules/HardwareStatus/FanStore.js
+++ b/src/store/modules/HardwareStatus/FanStore.js
@@ -33,7 +33,7 @@ const FanStore = {
           model: Model,
           name: Name,
           sparePartNumber: SparePartNumber,
-          status: Status.State,
+          status: Status?.State === 'Enabled' ? 'Present' : Status?.State,
           uri: fan['@odata.id'],
         };
       });

--- a/src/store/modules/HardwareStatus/MemoryStore.js
+++ b/src/store/modules/HardwareStatus/MemoryStore.js
@@ -31,7 +31,7 @@ const MemoryStore = {
           enabled: Enabled,
           partNumber: PartNumber,
           serialNumber: SerialNumber,
-          status: Status.State,
+          status: Status?.State === 'Enabled' ? 'Present' : Status?.State,
           sparePartNumber: SparePartNumber,
           model: Model,
           identifyLed: LocationIndicatorActive,

--- a/src/store/modules/HardwareStatus/PowerSupplyStore.js
+++ b/src/store/modules/HardwareStatus/PowerSupplyStore.js
@@ -35,7 +35,7 @@ const PowerSupplyStore = {
           model: Model,
           name: Name,
           sparePartNumber: SparePartNumber,
-          status: Status.State,
+          status: Status?.State === 'Enabled' ? 'Present' : Status?.State,
           uri: powerSupply['@odata.id'],
         };
       });

--- a/src/store/modules/HardwareStatus/ProcessorStore.js
+++ b/src/store/modules/HardwareStatus/ProcessorStore.js
@@ -31,7 +31,7 @@ const ProcessorStore = {
           partNumber: PartNumber,
           sparePartNumber: SparePartNumber,
           serialNumber: SerialNumber,
-          status: Status.State,
+          status: Status?.State === 'Enabled' ? 'Present' : Status?.State,
           model: Model,
           name: Name,
           processorType: ProcessorType,

--- a/src/views/HardwareStatus/Inventory/InventoryTableAssembly.vue
+++ b/src/views/HardwareStatus/Inventory/InventoryTableAssembly.vue
@@ -71,7 +71,7 @@
         {{
           isIoExpansionChassis && isPoweredOff
             ? $t('global.status.unavailable')
-            : row.item.status === 'Enabled'
+            : row.item.status === 'Present'
             ? $t('global.status.present')
             : $t('global.status.absent')
         }}

--- a/src/views/HardwareStatus/Inventory/InventoryTableDimmSlot.vue
+++ b/src/views/HardwareStatus/Inventory/InventoryTableDimmSlot.vue
@@ -61,7 +61,7 @@
       <!-- Status -->
       <template #cell(status)="row">
         {{
-          row.item.status === 'Enabled'
+          row.item.status === 'Present'
             ? $t('global.status.present')
             : $t('global.status.absent')
         }}

--- a/src/views/HardwareStatus/Inventory/InventoryTableFans.vue
+++ b/src/views/HardwareStatus/Inventory/InventoryTableFans.vue
@@ -73,7 +73,7 @@
         {{
           isIoExpansionChassis && isPoweredOff
             ? $t('global.status.unavailable')
-            : row.item.status === 'Enabled'
+            : row.item.status === 'Present'
             ? $t('global.status.present')
             : $t('global.status.absent')
         }}

--- a/src/views/HardwareStatus/Inventory/InventoryTablePowerSupplies.vue
+++ b/src/views/HardwareStatus/Inventory/InventoryTablePowerSupplies.vue
@@ -69,7 +69,7 @@
         {{
           isIoExpansionChassis && isPoweredOff
             ? $t('global.status.unavailable')
-            : row.item.status === 'Enabled'
+            : row.item.status === 'Present'
             ? $t('global.status.present')
             : $t('global.status.absent')
         }}

--- a/src/views/HardwareStatus/Inventory/InventoryTableProcessors.vue
+++ b/src/views/HardwareStatus/Inventory/InventoryTableProcessors.vue
@@ -60,7 +60,7 @@
       <!-- Status -->
       <template #cell(status)="row">
         {{
-          row.item.status === 'Enabled'
+          row.item.status === 'Present'
             ? $t('global.status.present')
             : $t('global.status.absent')
         }}


### PR DESCRIPTION
Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=511670

Description: Once user lands on the hardware-status/inventory, then click on search  for all the fields. Search is not working for all the fields in Inventory and LED page

Fix Screenshot:
<img width="665" alt="image" src="https://github.com/ibm-openbmc/webui-vue/assets/110152569/e6d10eef-7ccd-44a6-ab2a-a5522a8610b1">
