### PR TITLE
Fixed missing operations menu items tabs when opened in another session

### DIFF
--- a/src/store/modules/GlobalStore.js
+++ b/src/store/modules/GlobalStore.js
@@ -44,7 +44,7 @@ const GlobalStore = {
       ? JSON.parse(localStorage.getItem('storedUtcDisplay'))
       : true,
     username: localStorage.getItem('storedUsername'),
-    currentUser: JSON.parse(sessionStorage.getItem('storedCurrentUser')),
+    currentUser: JSON.parse(localStorage.getItem('storedCurrentUser')),
     isAuthorized: true,
     isServiceLoginEnabled: false,
   },
@@ -134,12 +134,12 @@ const GlobalStore = {
       { commit, getters },
       username = localStorage.getItem('storedUsername')
     ) {
-      if (sessionStorage.getItem('storedCurrentUser')) return;
+      if (localStorage.getItem('storedCurrentUser')) return;
       return api
         .get(`/redfish/v1/AccountService/Accounts/${username}`)
         .then(({ data }) => {
           commit('setCurrentUser', data);
-          sessionStorage.setItem(
+          localStorage.setItem(
             'storedCurrentUser',
             JSON.stringify(getters.currentUser)
           );


### PR DESCRIPTION
Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=421289

Description: Once user lands on page and click on the navigation menu, under the operations menu host console and service login console are not displaying when opened in another session.

Fix Screenshot:
<img width="518" alt="image" src="https://github.com/ibm-openbmc/webui-vue/assets/110152569/3f160b6a-d702-43fc-8b1d-d5f107e112f3">
another session screenshot: 
<img width="488" alt="image" src="https://github.com/ibm-openbmc/webui-vue/assets/110152569/7dead319-bbe9-40a3-9c25-f53d7059f36f">
