### PR TITLE
Fixed Success message on system identify LEDs in Overview page

### DIFF
--- a/src/views/Overview/OverviewInventory.vue
+++ b/src/views/Overview/OverviewInventory.vue
@@ -29,12 +29,14 @@
 
 <script>
 import OverviewCard from './OverviewCard';
+import BVToastMixin from '@/components/Mixins/BVToastMixin';
 
 export default {
   name: 'Inventory',
   components: {
     OverviewCard,
   },
+  mixins: [BVToastMixin],
   computed: {
     systems() {
       let systemData = this.$store.getters['system/systems'][0];
@@ -50,6 +52,7 @@ export default {
     toggleIdentifyLedSwitch(state) {
       this.$store
         .dispatch('system/changeIdentifyLedState', state)
+        .then((message) => this.successToast(message))
         .catch(({ message }) => this.errorToast(message));
     },
   },


### PR DESCRIPTION
Defect:https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=545203
Description: Once user lands on the Overview Page, on click of ON/OFF on system Identify LEDs unable to see the success
Message toaster .

screenshot:
![image](https://github.com/ibm-openbmc/webui-vue/assets/110152569/7ae72e99-d09c-4545-976e-f9102c271f49)
