### PR TITLE
1LA: Runtime Processor Diagnostics Updated

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -929,20 +929,21 @@
     "lateralCastOutDescription": "Only change this value if instructed by your service provider as it might degrade system performance.",
     "rpdPolicy": "Runtime processor diagnostic policy",
     "updateRpdPolicy": "Update RPD policy",
-    "rpdPolicyDescription": "Enabled (Run on each core once daily, at an equally spaced interval, to test each core every 24 hours. For example, on a 48-core system, the RPD would test one core every 30 minutes), Scheduled (Run sequentially on each core at the scheduled time each day for the specified duration (in minutes)), Disabled (No diagnostics or exercisers will be run). ",
+    "rpdPolicyDescription": "Enabled (Run on each core to test them on periodic basis), Scheduled (Run sequentially on each core at the scheduled time each day for the specified duration (in minutes)), Disabled (No diagnostics or exercisers will be run).",
     "rpdFeature": "Runtime processor diagnostic feature",
-    "updateRpdFeature": "Update RPD feature policy",
+    "updateRpdFeature": "Update RPD feature",
     "rpdFeatureDescription": "Controls whether or not the Runtime Processor Diagnostics (RPD) Feature will be configured on the system. Enabled ( The RPD feature will be configured regardless of the amount of installed memory), Automatic (The RPD feature will be configured on systems with at least 128GB of installed memory and not configured on systems with less than 128GB), Disabled (The RPD feature will not be configured).",
-    "startTime": "Start time",
+    "startTime": "Start time (24-hour time (UTC))",
     "runNow": "Run now",
-    "duration": "Duration",
+    "duration": "Duration (minutes)",
     "immediateTestRequested": "Immediate Test Requested",
-    "immediateTestRequestedDescription": "On pressing the Run now button the RPD policy will be overriden and diagnostic test run will start immediately and the button will be greyed out untill the test runs. RPD will set RPD immediate test to “Disabled” when an immediate test run completes",
-    "rpdScheduledRun": "RPD scheduled run time of day in Seconds",
-    "rpdScheduledRunDescription": "Only used when RPD policy is set to “Scheduled”. This value represents the time of day in seconds at which to run the processor diagnostics.",
+    "immediateTestRequestedDescription": "On pressing the Run now button the RPD policy will be overriden and diagnostic test run will start immediately and the button will be greyed out untill the test runs.",
+    "rpdScheduledRun": "RPD scheduled run time of day",
+    "rpdScheduledRunDescription": "Only used when RPD policy is set to “Scheduled”. This value represents the time of day at which to run the processor diagnostics.",
     "updateRpdScheduledRun": "Update RPD scheduled run",
     "gardOnError": "GARD on error",
     "gardOnErrorDescription": "Controls whether or not a processor core will be de-configured on error.",
+    "stopTest": "Stop diagnostic test run",
     "toast": {
       "errorSavingAggressivePrefetch": "Error saving aggressive prefetch",
       "errorSavingFrequencyCap": "Error saving frequency cap",
@@ -959,7 +960,7 @@
       "successSavingGardOnError": "Gard on error saved successfully",
       "successSavingLateralCastOut": "Lateral cast out mode saved successfully",
       "successSavingRpdPolicy": "RPD policy saved successfully",
-      "successSavingRpdFeature": "RPD feature saved successfully."
+      "successSavingRpdFeature": "RPD feature saved successfully. Changes made will take effect on next reboot."
     }
   },
   "pageLdap": {

--- a/src/store/modules/ResourceManagement/SystemParametersStore.js
+++ b/src/store/modules/ResourceManagement/SystemParametersStore.js
@@ -297,10 +297,14 @@ const systemParametersStore = {
           );
         });
     },
-    async saveImmediateTestRequested({ commit }) {
-      commit('setImmediateTestRequested', true);
+    async saveImmediateTestRequested({ commit }, { value }) {
+      if (value === 'Enabled') {
+        commit('setImmediateTestRequested', true);
+      } else {
+        commit('setImmediateTestRequested', false);
+      }
       const updatedImmediateTestRequestedValue = {
-        Attributes: { pvm_rpd_immediate_test: 'Enabled' },
+        Attributes: { pvm_rpd_immediate_test: value },
       };
       return api
         .patch(
@@ -314,7 +318,11 @@ const systemParametersStore = {
         })
         .catch((error) => {
           console.log(error);
-          commit('setImmediateTestRequested', false);
+          if (value === 'Enabled') {
+            commit('setImmediateTestRequested', false);
+          } else {
+            commit('setImmediateTestRequested', true);
+          }
           throw new Error(
             i18n.t(
               'pageSystemParameters.toast.errorSavingImmediateTestRequested'

--- a/src/views/HardwareStatus/Inventory/Inventory.vue
+++ b/src/views/HardwareStatus/Inventory/Inventory.vue
@@ -336,6 +336,11 @@ export default {
       this.getAllInfo('watched');
     },
   },
+  watch: {
+    currentTab: function () {
+      this.getAllInfo('watched');
+    },
+  },
   created() {
     this.getAllInfo('created');
   },

--- a/src/views/HardwareStatus/Inventory/Inventory.vue
+++ b/src/views/HardwareStatus/Inventory/Inventory.vue
@@ -336,11 +336,6 @@ export default {
       this.getAllInfo('watched');
     },
   },
-  watch: {
-    currentTab: function () {
-      this.getAllInfo('watched');
-    },
-  },
   created() {
     this.getAllInfo('created');
   },

--- a/src/views/ResourceManagement/SystemParameters/RuntimeProcessorDiagnostic.vue
+++ b/src/views/ResourceManagement/SystemParameters/RuntimeProcessorDiagnostic.vue
@@ -179,9 +179,18 @@
         type="submit"
         class="ml-3"
         :disabled="immediateTestRequestedState || isRpdFeatureCurrentDisabled"
-        @click="updateImmediateTestRequestedState()"
+        @click="updateImmediateTestRequestedState(true)"
       >
         {{ $t('pageSystemParameters.runNow') }}
+      </b-button>
+      <b-button
+        variant="danger"
+        type="submit"
+        class="ml-3"
+        :disabled="!immediateTestRequestedState || isRpdFeatureCurrentDisabled"
+        @click="updateImmediateTestRequestedState(false)"
+      >
+        {{ $t('pageSystemParameters.stopTest') }}
       </b-button>
     </b-row>
   </div>
@@ -319,10 +328,12 @@ export default {
     },
   },
   methods: {
-    updateImmediateTestRequestedState() {
+    updateImmediateTestRequestedState(value) {
       this.startLoader();
       Promise.all([
-        this.$store.dispatch('systemParameters/saveImmediateTestRequested'),
+        this.$store.dispatch('systemParameters/saveImmediateTestRequested', {
+          value: value ? 'Enabled' : 'Disabled',
+        }),
         this.$store.dispatch('systemParameters/getRpdScheduledRun'),
       ]).finally(() => this.endLoader());
     },


### PR DESCRIPTION
1. RPD feature -> In toast message added -> Changes made will be available in next reboot.
2. RPD policy helptext -> Enabled (Run on each core to test them on periodic basis), Scheduled (Run sequentially on each core at the scheduled time each day for the specified duration (in minutes)), Disabled (No diagnostics or exercisers will be run).
3. RPD scheduled run time of day -> 
    1. Removed in seconds from title and description.
	2. Updated "Duration" to "Duration (minutes)".
	3. Updated "Start time" to "Start time (24-hour time (UTC))".
4. Immediate Test Requested 
    1. helptext -> On pressing the Run now button the RPD policy will be overriden and diagnostic test run will start immediately and the button will be greyed out untill the test runs.
	2. Added Button and named "Stop diagnostic test run" on click of which we are changing the Attribute `pvm_rpd_immediate_test` to 'Disabled'.