### PR TITLE
Fixed PCIe Slots reload issue on toggle

### DIFF
--- a/src/store/modules/HardwareStatus/PcieSlotsStore.js
+++ b/src/store/modules/HardwareStatus/PcieSlotsStore.js
@@ -46,7 +46,6 @@ const PcieSlotsStore = {
       return await api
         .patch(`${led.uri}/PCIeSlots`, updatedIdentifyLedValue)
         .then(() => {
-          dispatch('getPcieSlotsInfo', { uri: led.uri });
           if (led.identifyLed) {
             return i18n.t('pageInventory.toast.successEnableIdentifyLed');
           } else {


### PR DESCRIPTION
- When we toggle the identify LEDs of the PCIe Slots, the whole table reloads and displays "No items available". This issue is fixed here.
- Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=549974