### PR TITLE
Fixed success message on delete all error logs operation

### DIFF
--- a/src/views/Logs/EventLogs/EventLogs.vue
+++ b/src/views/Logs/EventLogs/EventLogs.vue
@@ -638,10 +638,7 @@ export default {
             if (deleteConfirmed) {
               if (this.selectedRows.length === this.allLogs.length) {
                 this.$store
-                  .dispatch(
-                    'eventLog/deleteAllEventLogs',
-                    this.selectedRows.length
-                  )
+                  .dispatch('eventLog/deleteAllEventLogs', this.selectedRows)
                   .then((message) => {
                     this.reloadEventLogData();
                     this.successToast(message);


### PR DESCRIPTION
Defect:  https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=511514
Description: Fixed wrong notification seeing when we performed the delete all error logs operation.
Screenshot:
<img width="748" alt="image" src="https://github.com/ibm-openbmc/webui-vue/assets/110152569/52c91ff2-86ea-424b-8838-b29e474e0186">
