### PR TITLE
Added toast messages for Scheduled and Immediate test requests

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -948,20 +948,23 @@
     "toast": {
       "errorSavingAggressivePrefetch": "Error saving aggressive prefetch",
       "errorSavingFrequencyCap": "Error saving frequency cap",
-      "errorSavingImmediateTestRequested": "Error saving immediate test request",
       "errorSavingGardOnError": "Error saving Gard on error",
       "errorSavingLateralCastOut": "Error saving lateral cast out mode",
       "errorSavingRpdPolicy": "Error saving RPD policy",
       "errorSavingRpdFeature": "Error saving RPD feature",
       "errorSavingRpdRun": "Error saving RPD scheduled run",
-      "successSavingRpdRun": "RPD scheduled run saved successfully",
+      "errorStartingDiagnosticTestRun": "Error starting diagnostic test run",
+      "errorStoppingDiagnosticTestRun": "Error stopping diagnostic test run",
+      "successSavingRpdRun": "RPD scheduled run saved successfully. NOTE: System must be powered on at RPD scheduled run time of day, else the diagnostic test run will take effect on the next available schedule.",
       "successSavingAggressivePrefetch": "Aggressive prefetch saved successfully",
       "successSavingFrequencyCap": "Frequency cap saved successfully",
-      "successSavingImmediateTestRequested": "Immediate test request saved successfully",
       "successSavingGardOnError": "Gard on error saved successfully",
       "successSavingLateralCastOut": "Lateral cast out mode saved successfully",
       "successSavingRpdPolicy": "RPD policy saved successfully",
-      "successSavingRpdFeature": "RPD feature saved successfully. Changes made will take effect on next reboot."
+      "successSavingRpdFeature": "RPD feature saved successfully. Changes made will take effect on next reboot.",
+      "successStartingDiagnosticTestRun": "Diagnostic test run started successfully",
+      "successStartingDiagnosticTestRunIfPoweredOff": "Diagnostic test run saved successfully, Tests will start once the system is powered on.",
+      "successStoppingDiagnosticTestRun": "Diagnostic test run stopped successfully"
     }
   },
   "pageLdap": {

--- a/src/store/modules/ResourceManagement/SystemParametersStore.js
+++ b/src/store/modules/ResourceManagement/SystemParametersStore.js
@@ -312,22 +312,33 @@ const systemParametersStore = {
           updatedImmediateTestRequestedValue
         )
         .then(() => {
-          return i18n.t(
-            'pageSystemParameters.toast.successSavingImmediateTestRequested'
-          );
+          if (value === 'Enabled') {
+            return i18n.t(
+              'pageSystemParameters.toast.successStartingDiagnosticTestRun'
+            );
+          } else {
+            return i18n.t(
+              'pageSystemParameters.toast.successStoppingDiagnosticTestRun'
+            );
+          }
         })
         .catch((error) => {
           console.log(error);
           if (value === 'Enabled') {
             commit('setImmediateTestRequested', false);
+            throw new Error(
+              i18n.t(
+                'pageSystemParameters.toast.errorStartingDiagnosticTestRun'
+              )
+            );
           } else {
             commit('setImmediateTestRequested', true);
+            throw new Error(
+              i18n.t(
+                'pageSystemParameters.toast.errorStoppingDiagnosticTestRun'
+              )
+            );
           }
-          throw new Error(
-            i18n.t(
-              'pageSystemParameters.toast.errorSavingImmediateTestRequested'
-            )
-          );
         });
     },
     async saveGardOnError({ commit }, updatedImmediateTestRequested) {

--- a/src/views/ResourceManagement/SystemParameters/RuntimeProcessorDiagnostic.vue
+++ b/src/views/ResourceManagement/SystemParameters/RuntimeProcessorDiagnostic.vue
@@ -307,6 +307,12 @@ export default {
         return newValue;
       },
     },
+    serverStatus() {
+      return this.$store.getters['global/serverStatus'];
+    },
+    isServerOff() {
+      return this.serverStatus === 'off' ? true : false;
+    },
   },
   validations() {
     return {
@@ -335,7 +341,20 @@ export default {
           value: value ? 'Enabled' : 'Disabled',
         }),
         this.$store.dispatch('systemParameters/getRpdScheduledRun'),
-      ]).finally(() => this.endLoader());
+      ])
+        .then((message) => {
+          if (value && this.isServerOff) {
+            this.successToast(
+              this.$t(
+                'pageSystemParameters.toast.successStartingDiagnosticTestRunIfPoweredOff'
+              )
+            );
+          } else {
+            this.successToast(message);
+          }
+        })
+        .catch(({ message }) => this.errorToast(message))
+        .finally(() => this.endLoader());
     },
     updateGardOnErrorState(state) {
       this.$store


### PR DESCRIPTION
- On click of Run now and Stop diagnostic test run, toast messages are added in the System parameters page.
- Defects: 
https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=550657
https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=550652