### PR TITLE
Move webui-vue to use Context

### DIFF
--- a/src/store/modules/SecurityAndAccess/SessionsStore.js
+++ b/src/store/modules/SecurityAndAccess/SessionsStore.js
@@ -32,7 +32,7 @@ const SessionsStore = {
               ? sessionUri.data?.ClientOriginIPAddress.slice(7)
               : sessionUri.data?.ClientOriginIPAddress;
             return {
-              clientID: sessionUri.data?.Oem?.OpenBMC.ClientID,
+              clientID: sessionUri.data?.Context,
               username: sessionUri.data?.UserName,
               ipAddress: filteredIPAddress,
               uri: sessionUri.data['@odata.id'],


### PR DESCRIPTION
Context was added to Redfish to replace IBM OEM ClentID. Upstream backed moved at
https://gerrit.openbmc.org/c/openbmc/bmcweb/+/60124 and openbmc/bmcweb@7b395d7

Tested: I built 1050 with this change and
https://github.com/ibm-openbmc/bmcweb/pull/708.

```
curl -k -X POST -d "{\"UserName\": \"serxxxx\", \"Password\":
\"0penyyy\", \"Context\": \"Foobar\"}" https://$bmc/redfish/v1/SessionService/Sessions
{
  "@odata.id": "/redfish/v1/SessionService/Sessions/T65IkDm8Lb",
  "@odata.type": "#Session.v1_5_0.Session",
  "ClientOriginIPAddress": "9.3.84.13",
  "Context": "Foobar",

```