### PR TITLE
Updated the payload for ACF certificates

### DIFF
--- a/src/store/modules/SecurityAndAccess/CertificatesStore.js
+++ b/src/store/modules/SecurityAndAccess/CertificatesStore.js
@@ -158,7 +158,7 @@ const CertificatesStore = {
         Oem: {
           IBM: {
             ACF: {
-              ACFFile: base64File.split('base64,')[1].slice(0, -1),
+              ACFFile: base64File.split('base64,')[1],
             },
           },
         },
@@ -187,7 +187,7 @@ const CertificatesStore = {
         Oem: {
           IBM: {
             ACF: {
-              ACFFile: base64File.split('base64,')[1].slice(0, -1),
+              ACFFile: base64File.split('base64,')[1],
             },
           },
         },
@@ -228,7 +228,7 @@ const CertificatesStore = {
         Oem: {
           IBM: {
             ACF: {
-              ACFFile: base64File.split('base64,')[1].slice(0, -1),
+              ACFFile: base64File.split('base64,')[1],
             },
           },
         },


### PR DESCRIPTION
- In the Certificates page, the last character of the base64 payload was being removed previously in the replace/add ACF certificate, Now, that is fixed in this change.
- Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=550987