### PR TITLE
Adding Led's to enhance use experience

### DIFF
--- a/src/components/Global/LedComponent.vue
+++ b/src/components/Global/LedComponent.vue
@@ -1,0 +1,133 @@
+<template>
+  <button class="ui button toggle mybtn" :class="[btnColour, 'mybtn']"></button>
+</template>
+<script>
+export default {
+  name: 'LedComponent',
+  props: {
+    id: { type: String, default: '' },
+    onColour: { type: String, default: 'green' },
+    offColour: { type: String, default: 'white' },
+    errColour: { type: String, default: 'amber' },
+    ledValue: { type: Boolean, default: false },
+    isSolidLed: { type: Boolean, default: false },
+    isServiceLed: { type: Boolean, default: false },
+    issysAttentionLed: { type: Boolean, default: false },
+    issysidentifyLed: { type: Boolean, default: false },
+    health: { type: String, default: '' },
+  },
+  data() {
+    return {
+      checkbox: false,
+      blinkcolour: false,
+      btnColour: 'white',
+      intervalId: 0,
+      onColours: this.onColour,
+      offColours: this.offColour,
+      errColours: 'red',
+      cid: this.id,
+    };
+  },
+  mounted() {
+    if (this.isServiceLed && this.isSolidLed) {
+      clearInterval(this.intervalId);
+      if (this.ledValue === `global.status.on`) {
+        this.turnon();
+      } else {
+        this.startBlinking();
+      }
+    } else if (this.isServiceLed) {
+      if (this.isServiceLed && this.issysidentifyLed) {
+        this.issysidentifyLed ? this.turnon() : this.turnoff();
+      } else if (this.isServiceLed && this.issysAttentionLed) {
+        this.issysAttentionLed ? this.turnon() : this.turnoff();
+      }
+    } else {
+      if (!(this.health === 'Critical')) {
+        if (this.ledValue) {
+          this.startBlinking();
+        } else {
+          this.stopBlinking();
+        }
+      } else {
+        this.turnon();
+      }
+    }
+  },
+  methods: {
+    myFunction() {
+      if (this.blinkcolour) {
+        this.turnoff();
+      } else {
+        this.turnon();
+      }
+    },
+    turnoff() {
+      this.blinkcolour = false;
+      this.btnColour = this.offColour;
+    },
+    turnon() {
+      this.blinkcolour = true;
+      this.btnColour = this.onColour;
+    },
+
+    toggleCheckbox() {
+      this.checkbox = true;
+      if (this.blinkcolour) {
+        this.turnoff();
+        this.blinkcolour = false;
+      } else {
+        this.turnon();
+        this.blinkcolour = true;
+      }
+      this.intervalId = setInterval(this.myFunction, 500);
+    },
+
+    turnErrorColor() {
+      if (this.checkbox) {
+        this.stopBlinking();
+      }
+      this.blinkcolour = true;
+      this.btnColour = this.errColours;
+    },
+
+    stopBlinking() {
+      clearInterval(this.intervalId);
+      this.turnoff();
+      this.checkbox = false;
+    },
+    startBlinking() {
+      if (!this.checkbox) this.toggleCheckbox();
+    },
+  },
+};
+</script>
+
+<style scoped>
+.mybtn {
+  border-radius: 50%;
+  padding: 12px;
+  border-color: black;
+  color: black;
+  outline-color: black;
+}
+
+.green {
+  background-color: green;
+}
+.blue {
+  background-color: #0029e0;
+}
+.amber {
+  background-color: #ffb300;
+}
+.red {
+  background-color: red;
+}
+.white {
+  background-color: white;
+}
+.lightgrey {
+  background-color: lightgrey;
+}
+</style>

--- a/src/store/modules/HardwareStatus/BmcStore.js
+++ b/src/store/modules/HardwareStatus/BmcStore.js
@@ -17,6 +17,7 @@ const BmcStore = {
       bmc.health = data.Status.Health;
       bmc.id = data.Id;
       bmc.identifyLed = data.LocationIndicatorActive;
+      bmc.ledStatus = data.LocationIndicatorActive;
       bmc.locationNumber = data.Location?.PartLocation?.ServiceLabel;
       bmc.model = data.Model;
       bmc.name = data.Name;

--- a/src/store/modules/HardwareStatus/FanStore.js
+++ b/src/store/modules/HardwareStatus/FanStore.js
@@ -29,6 +29,7 @@ const FanStore = {
           partNumber: PartNumber,
           serialNumber: SerialNumber,
           identifyLed: LocationIndicatorActive,
+          ledStatus: LocationIndicatorActive,
           locationNumber: Location?.PartLocation?.ServiceLabel,
           model: Model,
           name: Name,

--- a/src/store/modules/HardwareStatus/PcieSlotsStore.js
+++ b/src/store/modules/HardwareStatus/PcieSlotsStore.js
@@ -16,6 +16,7 @@ const PcieSlotsStore = {
         return {
           type: SlotType,
           identifyLed: LocationIndicatorActive,
+          ledStatus: LocationIndicatorActive,
           locationNumber: Location?.PartLocation?.ServiceLabel,
         };
       });

--- a/src/store/modules/HardwareStatus/PowerSupplyStore.js
+++ b/src/store/modules/HardwareStatus/PowerSupplyStore.js
@@ -31,6 +31,7 @@ const PowerSupplyStore = {
           serialNumber: SerialNumber,
           firmwareVersion: FirmwareVersion,
           identifyLed: LocationIndicatorActive,
+          ledStatus: LocationIndicatorActive,
           locationNumber: Location?.PartLocation?.ServiceLabel,
           model: Model,
           name: Name,

--- a/src/store/modules/HardwareStatus/ProcessorStore.js
+++ b/src/store/modules/HardwareStatus/ProcessorStore.js
@@ -38,6 +38,7 @@ const ProcessorStore = {
           totalCores: TotalCores,
           locationNumber: Location?.PartLocation?.ServiceLabel,
           identifyLed: LocationIndicatorActive,
+          ledStatus: LocationIndicatorActive,
           uri: processor['@odata.id'],
         };
       });

--- a/src/store/modules/HardwareStatus/SystemStore.js
+++ b/src/store/modules/HardwareStatus/SystemStore.js
@@ -21,11 +21,14 @@ const SystemStore = {
       system.sysAttentionLed =
         data.Oem?.IBM?.PartitionSystemAttentionIndicator ||
         data.Oem?.IBM?.PlatformSystemAttentionIndicator;
+      system.issysAttentionLed = system.sysAttentionLed;
       system.locationIndicatorActive = data.LocationIndicatorActive;
+      system.issysidentifyLed = data.LocationIndicatorActive;
       system.model = data.Model;
       system.processorSummaryCoreCount = data.ProcessorSummary?.CoreCount;
       system.processorSummaryCount = data.ProcessorSummary?.Count;
       system.powerState = data.PowerState;
+      system.powerLedStatus = data.PowerState;
       system.serialNumber = data.SerialNumber;
       system.statusState = data.Status?.State;
       state.systems = [system];
@@ -45,6 +48,32 @@ const SystemStore = {
       return await api
         .patch('/redfish/v1/Systems/system', {
           LocationIndicatorActive: ledState,
+        })
+        .then(() => {
+          if (ledState) {
+            return i18n.t('pageInventory.toast.successEnableIdentifyLed');
+          } else {
+            return i18n.t('pageInventory.toast.successDisableIdentifyLed');
+          }
+        })
+        .catch((error) => {
+          commit('setSystemInfo', this.state.system.systems[0]);
+          console.log('error', error);
+          if (ledState) {
+            throw new Error(
+              i18n.t('pageInventory.toast.errorEnableIdentifyLed')
+            );
+          } else {
+            throw new Error(
+              i18n.t('pageInventory.toast.errorDisableIdentifyLed')
+            );
+          }
+        });
+    },
+    async PowerStatusLedState({ commit }, ledState) {
+      return await api
+        .patch('/redfish/v1/Systems/system', {
+          powerLedStatus: ledState,
         })
         .then(() => {
           if (ledState) {

--- a/src/views/HardwareStatus/Inventory/InventoryFabricAdapters.vue
+++ b/src/views/HardwareStatus/Inventory/InventoryFabricAdapters.vue
@@ -91,6 +91,18 @@
         </b-form-checkbox>
         <div v-else>--</div>
       </template>
+
+      <template #cell(ledStatus)="row">
+        <led-component
+          v-if="hasIdentifyLed(row.item.identifyLed)"
+          :ref="`identifyfabricLedRef${row.item.name}`"
+          :led-value="row.item.identifyLed"
+          off-colour="white"
+          on-colour="amber"
+        ></led-component>
+        <div v-else>--</div>
+      </template>
+
       <template #row-details="{ item }">
         <b-container fluid>
           <b-row>
@@ -136,9 +148,16 @@ import TableRowExpandMixin, {
   expandRowLabel,
 } from '@/components/Mixins/TableRowExpandMixin';
 import BVToastMixin from '@/components/Mixins/BVToastMixin';
+import LedComponent from '@/components/Global/LedComponent';
 
 export default {
-  components: { IconChevron, PageSection, Search, TableCellCount },
+  components: {
+    IconChevron,
+    PageSection,
+    Search,
+    TableCellCount,
+    LedComponent,
+  },
   mixins: [
     BVToastMixin,
     TableRowExpandMixin,
@@ -192,6 +211,11 @@ export default {
         {
           key: 'identifyLed',
           label: this.$t('pageInventory.table.identifyLed'),
+          formatter: this.dataFormatter,
+        },
+        {
+          key: 'ledStatus',
+          label: 'Physical LED State',
           formatter: this.dataFormatter,
         },
       ],
@@ -260,8 +284,17 @@ export default {
           memberId: row.id,
           identifyLed: row.identifyLed,
         })
-        .then((message) => this.successToast(message))
-        .catch(({ message }) => this.errorToast(message));
+        .then(() => {
+          if (row.identifyLed) {
+            this.$refs['identifyfabricLedRef' + `${row.name}`].startBlinking();
+          } else {
+            this.$refs['identifyfabricLedRef' + `${row.name}`].stopBlinking();
+          }
+        })
+        .catch(({ message }) => {
+          this.$refs['identifyfabricLedRef' + `${row.name}`].turnErrorColor();
+          this.errorToast(message);
+        });
     },
     sortCompare(a, b, key) {
       if (key === 'health') {

--- a/src/views/HardwareStatus/Inventory/InventoryTableFans.vue
+++ b/src/views/HardwareStatus/Inventory/InventoryTableFans.vue
@@ -95,6 +95,15 @@
         </b-form-checkbox>
       </template>
 
+      <template #cell(ledStatus)="row">
+        <led-component
+          :ref="`identifyLedFanRef${row.item.name}`"
+          :led-value="row.item.identifyLed"
+          off-colour="white"
+          on-colour="amber"
+        ></led-component>
+      </template>
+
       <template #row-details="{ item }">
         <b-container fluid>
           <b-row>
@@ -150,9 +159,17 @@ import TableRowExpandMixin, {
   expandRowLabel,
 } from '@/components/Mixins/TableRowExpandMixin';
 import BVToastMixin from '@/components/Mixins/BVToastMixin';
+import LedComponent from '@/components/Global/LedComponent';
 
 export default {
-  components: { IconChevron, PageSection, StatusIcon, Search, TableCellCount },
+  components: {
+    IconChevron,
+    PageSection,
+    StatusIcon,
+    Search,
+    TableCellCount,
+    LedComponent,
+  },
   mixins: [
     BVToastMixin,
     TableRowExpandMixin,
@@ -205,6 +222,11 @@ export default {
         {
           key: 'identifyLed',
           label: this.$t('pageInventory.table.identifyLed'),
+          formatter: this.dataFormatter,
+        },
+        {
+          key: 'ledStatus',
+          label: 'Physical LED State',
           formatter: this.dataFormatter,
         },
       ],
@@ -279,8 +301,17 @@ export default {
           uri: row.uri,
           identifyLed: row.identifyLed,
         })
-        .then((message) => this.successToast(message))
-        .catch(({ message }) => this.errorToast(message));
+        .then(() => {
+          if (row.identifyLed) {
+            this.$refs['identifyLedFanRef' + `${row.name}`].turnErrorColor();
+          } else {
+            this.$refs['identifyLedFanRef' + `${row.name}`].stopBlinking();
+          }
+        })
+        .catch(({ message }) => {
+          this.$refs.identifyLedFanRef`${row.name}`.turnErrorColor();
+          this.errorToast(message);
+        });
     },
   },
 };


### PR DESCRIPTION
- Adding custom LED component to enhance visual representation of physical LED State which will be dipict the original system LED colour and it's behaviour.
- When user toggle the identify LED button then as current behaviour toast message will be appears for the LED status but as part of this change when user toggle identify LED button then it's appears as LED button and colour of the LED continuously blinking based on toggle button status.
- For each toggle button behaviour is different as similar as Hardware LED colour code.
For example:
- Dimms, fans, processor etc LED colour representation are amber and system identify LED colour is blue as similar as Hardware colour.

New physical LED are looks like attached images:
<img width="1164" alt="dimm slot led" src="https://github.com/ibm-openbmc/webui-vue/assets/108823339/1e533867-5c23-44e9-9574-f72636c8c241">
<img width="1728" alt="power button led" src="https://github.com/ibm-openbmc/webui-vue/assets/108823339/28c151b0-c93f-42ef-8f31-a6bdaf4ee0a2">
<img width="1585" alt="sys attention led" src="https://github.com/ibm-openbmc/webui-vue/assets/108823339/9f57f935-43f8-4258-bac2-c31962bfa35b">

