### PR TITLE
Added delay in getting the tables in Network page

### DIFF
--- a/src/store/modules/Settings/NetworkStore.js
+++ b/src/store/modules/Settings/NetworkStore.js
@@ -119,6 +119,11 @@ const NetworkStore = {
           console.log('Network Data:', error);
         });
     },
+    async getEthernetDataAfterDelay({ dispatch }) {
+      setTimeout(() => {
+        dispatch('getEthernetData');
+      }, 10000);
+    },
     async saveDomainNameState({ commit, state, dispatch }, domainState) {
       commit('setDomainNameState', domainState);
       const data = {
@@ -215,7 +220,12 @@ const NetworkStore = {
           `/redfish/v1/Managers/bmc/EthernetInterfaces/${state.selectedInterfaceId}`,
           data
         )
-        .then(dispatch('getEthernetData'))
+        .then(() => {
+          // Getting Ethernet data here so that the toggle gets updated
+          dispatch('getEthernetData');
+          // Getting Ethernet data here so that the IPv4 table gets updated
+          dispatch('getEthernetDataAfterDelay');
+        })
         .then(() => {
           return i18n.t('pageNetwork.toast.successSaveNetworkSettings', {
             setting: i18n.t('pageNetwork.dhcp'),
@@ -244,7 +254,12 @@ const NetworkStore = {
           `/redfish/v1/Managers/bmc/EthernetInterfaces/${state.selectedInterfaceId}`,
           data
         )
-        .then(dispatch('getEthernetData'))
+        .then(() => {
+          // Getting Ethernet data here so that the toggle gets updated
+          dispatch('getEthernetData');
+          // Getting Ethernet data here so that the IPv6 table gets updated
+          dispatch('getEthernetDataAfterDelay');
+        })
         .then(() => {
           return i18n.t('pageNetwork.toast.successSaveNetworkSettings', {
             setting: i18n.t('pageNetwork.dhcp'),
@@ -320,9 +335,7 @@ const NetworkStore = {
           updatedIpv4Array
         )
         .then(() => {
-          setTimeout(() => {
-            dispatch('getEthernetData');
-          }, 10000);
+          dispatch('getEthernetDataAfterDelay');
         })
         .then(() => {
           return i18n.t('pageNetwork.toast.successSaveNetworkSettings', {
@@ -360,7 +373,9 @@ const NetworkStore = {
           `/redfish/v1/Managers/bmc/EthernetInterfaces/${state.selectedInterfaceId}`,
           updatedIpv6Array
         )
-        .then(dispatch('getEthernetData'))
+        .then(() => {
+          dispatch('getEthernetDataAfterDelay');
+        })
         .then(() => {
           return i18n.t('pageNetwork.toast.successSaveNetworkSettings', {
             setting: i18n.t('pageNetwork.ipv6'),

--- a/src/views/Settings/Network/Network.vue
+++ b/src/views/Settings/Network/Network.vue
@@ -168,16 +168,26 @@ export default {
         const editRow = modalData.concat(selectedRow);
         this.$store
           .dispatch('network/updateIpv4Address', editRow)
-          .then((message) => this.successToast(message))
-          .catch(({ message }) => this.errorToast(message))
-          .finally(() => this.endLoader());
+          .then((message) => {
+            this.successToast(message);
+            this.setEndLoaderAfterDelay();
+          })
+          .catch(({ message }) => {
+            this.errorToast(message);
+            this.endLoader();
+          });
       } else {
         // Add new address
         this.$store
           .dispatch('network/updateIpv4Address', modalData)
-          .then((message) => this.successToast(message))
-          .catch(({ message }) => this.errorToast(message))
-          .finally(() => this.endLoader());
+          .then((message) => {
+            this.successToast(message);
+            this.setEndLoaderAfterDelay();
+          })
+          .catch(({ message }) => {
+            this.errorToast(message);
+            this.endLoader();
+          });
       }
     },
     saveIpv6Address(modalFormData) {
@@ -189,16 +199,26 @@ export default {
         const editRow = modalData.concat(selectedRow);
         this.$store
           .dispatch('network/updateIpv6Address', editRow)
-          .then((message) => this.successToast(message))
-          .catch(({ message }) => this.errorToast(message))
-          .finally(() => this.endLoader());
+          .then((message) => {
+            this.successToast(message);
+            this.setEndLoaderAfterDelay();
+          })
+          .catch(({ message }) => {
+            this.errorToast(message);
+            this.endLoader();
+          });
       } else {
         // Add new address
         this.$store
           .dispatch('network/updateIpv6Address', modalData)
-          .then((message) => this.successToast(message))
-          .catch(({ message }) => this.errorToast(message))
-          .finally(() => this.endLoader());
+          .then((message) => {
+            this.successToast(message);
+            this.setEndLoaderAfterDelay();
+          })
+          .catch(({ message }) => {
+            this.errorToast(message);
+            this.endLoader();
+          });
       }
     },
     saveDnsAddress(modalFormData) {
@@ -216,6 +236,11 @@ export default {
         .then(this.$store.dispatch('authentication/logout'))
         .catch(({ message }) => this.errorToast(message))
         .finally(() => this.endLoader());
+    },
+    setEndLoaderAfterDelay() {
+      setTimeout(() => {
+        this.endLoader();
+      }, 10000);
     },
   },
 };

--- a/src/views/Settings/Network/TableIpv4.vue
+++ b/src/views/Settings/Network/TableIpv4.vue
@@ -247,7 +247,13 @@ export default {
           if (dhcpEnableConfirmed) {
             this.$store
               .dispatch('network/saveDhcpEnabledState', state)
-              .then((message) => this.successToast(message))
+              .then((message) => {
+                this.successToast(message);
+                this.startLoader();
+                setTimeout(() => {
+                  this.endLoader();
+                }, 10000);
+              })
               .catch(({ message }) => this.errorToast(message));
           } else {
             let onDhcpCancel = document.getElementById('dhcpSwitch');

--- a/src/views/Settings/Network/TableIpv6.vue
+++ b/src/views/Settings/Network/TableIpv6.vue
@@ -252,7 +252,13 @@ export default {
     changeIpv6DhcpEnabledState(state) {
       this.$store
         .dispatch('network/saveIpv6DhcpEnabledState', state)
-        .then((message) => this.successToast(message))
+        .then((message) => {
+          this.successToast(message);
+          this.startLoader();
+          setTimeout(() => {
+            this.endLoader();
+          }, 10000);
+        })
         .catch(({ message }) => this.errorToast(message));
     },
     changeIpv6AutoConfigState(state) {


### PR DESCRIPTION
- The Entries and DHCP values once updated, would take sometime to be updated, So, Added a 10 seconds delay in getting the values and then updating them in the table.

- Also added a loading bar for this delay.

- Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=484459