### PR TITLE
Fixed error message for read only user password change

### DIFF
--- a/src/store/modules/SecurityAndAccess/UserManagementStore.js
+++ b/src/store/modules/SecurityAndAccess/UserManagementStore.js
@@ -172,11 +172,7 @@ const UserManagementStore = {
           })
         )
         .catch((error) => {
-          console.log(error);
-
-          const messageId =
-            error.response.data['Password@Message.ExtendedInfo'][0].MessageId;
-
+          const messageId = error?.response?.data?.error?.code;
           const message =
             messageId === 'Base.1.8.1.PropertyValueFormatError'
               ? i18n.t(


### PR DESCRIPTION
Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=555863
Description: Readonly user is unable to modify its own password from GUI getting error.
Screenshot:
<img width="947" alt="image" src="https://github.com/ibm-openbmc/webui-vue/assets/110152569/b788b3dd-ae22-4b97-8b7c-731c16bcf7f8">
