### PR TITLE
Added delay to get the updated NTP date and time

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -391,7 +391,8 @@
     },
     "toast": {
       "errorSaveDateTime": "Error saving date and time settings.",
-      "successSaveDateTime": "Successfully saved date and time settings."
+      "successSaveDateTime": "Successfully saved date and time settings.",
+      "successSaveDateTimeForNtpServer": "Successfully saved date and time settings. It would take about 20 seconds to update date and time."
     }
   },
   "pageConcurrentMaintenance": {

--- a/src/store/modules/Settings/DateTimeStore.js
+++ b/src/store/modules/Settings/DateTimeStore.js
@@ -68,7 +68,11 @@ const DateTimeStore = {
           }
         })
         .then(() => {
-          return i18n.t('pageDateTime.toast.successSaveDateTime');
+          if (dateTimeForm.ntpProtocolEnabled) {
+            return i18n.t('pageDateTime.toast.successSaveDateTimeForNtpServer');
+          } else {
+            return i18n.t('pageDateTime.toast.successSaveDateTime');
+          }
         })
         .catch((error) => {
           console.log(error);

--- a/src/views/Settings/DateTime/DateTime.vue
+++ b/src/views/Settings/DateTime/DateTime.vue
@@ -434,10 +434,20 @@ export default {
           }
         })
         .then(() => {
-          this.$store.dispatch('global/getBmcTime');
+          if (!isNTPEnabled) {
+            this.$store.dispatch('global/getBmcTime');
+            this.$v.form.$reset();
+            this.endLoader();
+          } else {
+            this.startLoader();
+            setTimeout(() => {
+              this.$store.dispatch('global/getBmcTime');
+              this.endLoader();
+            }, 20000);
+          }
         })
-        .catch(({ message }) => this.errorToast(message))
-        .finally(() => {
+        .catch(({ message }) => {
+          this.errorToast(message);
           this.$v.form.$reset();
           this.endLoader();
         });


### PR DESCRIPTION
- After we update the manual date and time, if we try to update the NTP server. The date and tim ewould take about 20 seconds to update in the Redfish response when we retrieve from GUI. So, added a 20 seconds delay to get the date and time if we update the NTP server.
- Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=519418