### PR TITLE
Added Success Toast with reload message for HTTP certificate

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -351,7 +351,7 @@
       "errorDeleteCertificate": "Error deleting certificate.",
       "errorReplaceCertificate": "Error replacing certificate.",
       "successAddCertificate": "Successfully added %{certificate}.",
-      "successAddedHTTPCertificate": "Successfully added %{certificate}. Reload the browser page to see the changes",
+      "successAddedHTTPCertificate": "Successfully added %{certificate}. Reload the browser page to see the changes.",
       "successDeleteCertificate": "Successfully deleted %{certificate}.",
       "successReplaceCertificate": "Successfully replaced %{certificate}.",
       "successReplacedHTTPCertificate": "Successfully replaced %{certificate}. Reload the browser page to see the changes."

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -355,7 +355,6 @@
       "successDeleteCertificate": "Successfully deleted %{certificate}.",
       "successReplaceCertificate": "Successfully replaced %{certificate}.",
       "successReplacedHTTPCertificate": "Successfully replaced %{certificate}. Reload the browser page to see the changes."
-
     }
   },
   "pageChangePassword": {

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -351,8 +351,11 @@
       "errorDeleteCertificate": "Error deleting certificate.",
       "errorReplaceCertificate": "Error replacing certificate.",
       "successAddCertificate": "Successfully added %{certificate}.",
+      "successAddedHTTPCertificate": "Successfully added %{certificate}. Reload the browser page to see the changes",
       "successDeleteCertificate": "Successfully deleted %{certificate}.",
-      "successReplaceCertificate": "Successfully replaced %{certificate}."
+      "successReplaceCertificate": "Successfully replaced %{certificate}.",
+      "successReplacedHTTPCertificate": "Successfully replaced %{certificate}. Reload the browser page to see the changes."
+
     }
   },
   "pageChangePassword": {

--- a/src/store/modules/SecurityAndAccess/CertificatesStore.js
+++ b/src/store/modules/SecurityAndAccess/CertificatesStore.js
@@ -207,16 +207,26 @@ const CertificatesStore = {
         });
     },
     async addNewCertificate({ dispatch }, { file, type }) {
+      const typeOfCertificate = getCertificateProp(type, 'label');
       return await api
         .post(getCertificateProp(type, 'location'), file, {
           headers: { 'Content-Type': 'application/x-pem-file' },
         })
         .then(() => dispatch('getCertificates'))
-        .then(() =>
-          i18n.t('pageCertificates.toast.successAddCertificate', {
-            certificate: getCertificateProp(type, 'label'),
-          })
-        )
+        .then(() => {
+          if (typeOfCertificate === 'HTTPS Certificate') {
+            return i18n.t(
+              'pageCertificates.toast.successAddedHTTPCertificate',
+              {
+                certificate: getCertificateProp(type, 'label'),
+              }
+            );
+          } else {
+            return i18n.t('pageCertificates.toast.successAddCertificate', {
+              certificate: getCertificateProp(type, 'label'),
+            });
+          }
+        })
         .catch((error) => {
           console.log(error);
           throw new Error(i18n.t('pageCertificates.toast.errorAddCertificate'));
@@ -261,6 +271,7 @@ const CertificatesStore = {
       data.CertificateString = certificateString;
       data.CertificateType = 'PEM';
       data.CertificateUri = { '@odata.id': location };
+      const typeOfCertificate = getCertificateProp(type, 'label');
       return await api
         .post(
           '/redfish/v1/CertificateService/Actions/CertificateService.ReplaceCertificate',
@@ -271,9 +282,18 @@ const CertificatesStore = {
           dispatch('getCertificates');
         })
         .then(() => {
-          return i18n.t('pageCertificates.toast.successReplaceCertificate', {
-            certificate: getCertificateProp(type, 'label'),
-          });
+          if (typeOfCertificate === 'HTTPS Certificate') {
+            return i18n.t(
+              'pageCertificates.toast.successReplacedHTTPCertificate',
+              {
+                certificate: getCertificateProp(type, 'label'),
+              }
+            );
+          } else {
+            return i18n.t('pageCertificates.toast.successReplaceCertificate', {
+              certificate: getCertificateProp(type, 'label'),
+            });
+          }
         })
         .catch((error) => {
           console.log(error);


### PR DESCRIPTION
Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=544392

Description: After upload server certificate BMC GUI required Browser refreshment to reflect new changes. But there is no message saying that browser refresh is required to see the changes