### PR TITLE
Updated delete ACF certificate request body

### DIFF
--- a/src/store/modules/SecurityAndAccess/CertificatesStore.js
+++ b/src/store/modules/SecurityAndAccess/CertificatesStore.js
@@ -287,7 +287,7 @@ const CertificatesStore = {
         Oem: {
           IBM: {
             ACF: {
-              ACFFile: null,
+              ACFFile: '',
             },
           },
         },


### PR DESCRIPTION
- Request body was null when we delete ACF certificate, It is now updated to '' (empty string).
- Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=526191