### PR TITLE
Removed Alert and added info icons in system parameters page

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -919,10 +919,6 @@
   "pageSystemParameters": {
     "aggressivePrefetch": "Aggressive prefetch",
     "aggressivePrefetchDescription": "Only change this value if instructed by service provider as it might degrade system performance. Specifies if processor favor aggressive prefetch is disabled or enabled",
-    "alert": {
-      "message": "System has to be powered off. Changes made will take effect on next reboot",
-      "title": "Applying changes"
-    },
     "button": {
       "saveSettings": "Save settings"
     },
@@ -931,12 +927,14 @@
     "frequencyCapHelpText": "If disabled, might require an initial boot to get the max and min frequency to be able to set.",
     "lateralCastOut": "Lateral cast out",
     "lateralCastOutDescription": "Only change this value if instructed by your service provider as it might degrade system performance.",
+    "parametersInfo": "System has to be powered off. Changes made will take effect on next reboot.",
     "rpdPolicy": "Runtime processor diagnostic policy",
     "updateRpdPolicy": "Update RPD policy",
     "rpdPolicyDescription": "Enabled (Run on each core to test them on periodic basis), Scheduled (Run sequentially on each core at the scheduled time each day for the specified duration (in minutes)), Disabled (No diagnostics or exercisers will be run).",
     "rpdFeature": "Runtime processor diagnostic feature",
     "updateRpdFeature": "Update RPD feature",
     "rpdFeatureDescription": "Controls whether or not the Runtime Processor Diagnostics (RPD) Feature will be configured on the system. Enabled ( The RPD feature will be configured regardless of the amount of installed memory), Automatic (The RPD feature will be configured on systems with at least 128GB of installed memory and not configured on systems with less than 128GB), Disabled (The RPD feature will not be configured).",
+    "rpdFeatureInfo": "Changes made to RPD feature requires a reboot to take effect but all other RPD parameters can be set dynamically at runtime.",
     "startTime": "Start time (24-hour time (UTC))",
     "runNow": "Run now",
     "duration": "Duration (minutes)",

--- a/src/views/ResourceManagement/SystemParameters/AggressivePrefetch.vue
+++ b/src/views/ResourceManagement/SystemParameters/AggressivePrefetch.vue
@@ -4,6 +4,7 @@
       <dl class="mt-3 mr-3 w-75">
         <dt id="aggressive-prefetch-label">
           {{ $t('pageSystemParameters.aggressivePrefetch') }}
+          <info-tooltip :title="$t('pageSystemParameters.parametersInfo')" />
         </dt>
         <dd id="aggressive-prefetch-description">
           {{ $t('pageSystemParameters.aggressivePrefetchDescription') }}
@@ -27,11 +28,13 @@
 </template>
 
 <script>
+import InfoTooltip from '@/components/Global/InfoTooltip';
 import BVToastMixin from '@/components/Mixins/BVToastMixin';
 import LoadingBarMixin from '@/components/Mixins/LoadingBarMixin';
 
 export default {
   name: 'AggressivePrefetch',
+  components: { InfoTooltip },
   mixins: [LoadingBarMixin, BVToastMixin],
   props: {
     safeMode: {

--- a/src/views/ResourceManagement/SystemParameters/FrequencyCap.vue
+++ b/src/views/ResourceManagement/SystemParameters/FrequencyCap.vue
@@ -6,7 +6,11 @@
           <dt id="frequency-cap-label">
             {{ $t('pageSystemParameters.frequencyCap') }}
             <info-tooltip
-              :title="$t('pageSystemParameters.frequencyCapHelpText')"
+              :title="
+                $t('pageSystemParameters.parametersInfo') +
+                ' ' +
+                $t('pageSystemParameters.frequencyCapHelpText')
+              "
             />
           </dt>
           <dd id="frequency-cap-description">

--- a/src/views/ResourceManagement/SystemParameters/LateralCastOut.vue
+++ b/src/views/ResourceManagement/SystemParameters/LateralCastOut.vue
@@ -5,6 +5,7 @@
         <dl class="mr-3 w-75">
           <dt id="ateral-cast-out-label">
             {{ $t('pageSystemParameters.lateralCastOut') }}
+            <info-tooltip :title="$t('pageSystemParameters.parametersInfo')" />
           </dt>
           <dd id="lateral-cast-out-description">
             {{ $t('pageSystemParameters.lateralCastOutDescription') }}
@@ -29,11 +30,13 @@
 </template>
 
 <script>
+import InfoTooltip from '@/components/Global/InfoTooltip';
 import BVToastMixin from '@/components/Mixins/BVToastMixin';
 import LoadingBarMixin from '@/components/Mixins/LoadingBarMixin';
 
 export default {
   name: 'LateralCastOut',
+  components: { InfoTooltip },
   mixins: [LoadingBarMixin, BVToastMixin],
   props: {
     safeMode: {

--- a/src/views/ResourceManagement/SystemParameters/RuntimeProcessorDiagnostic.vue
+++ b/src/views/ResourceManagement/SystemParameters/RuntimeProcessorDiagnostic.vue
@@ -5,6 +5,7 @@
         <dl class="mt-3 mr-3 w-75">
           <dt id="rpd-policy-label">
             {{ $t('pageSystemParameters.rpdFeature') }}
+            <info-tooltip :title="$t('pageSystemParameters.rpdFeatureInfo')" />
           </dt>
           <dd id="rpd-policy-description">
             {{ $t('pageSystemParameters.rpdFeatureDescription') }}
@@ -197,6 +198,7 @@
 </template>
 
 <script>
+import InfoTooltip from '@/components/Global/InfoTooltip';
 import BVToastMixin from '@/components/Mixins/BVToastMixin';
 import LoadingBarMixin from '@/components/Mixins/LoadingBarMixin';
 import { mapGetters } from 'vuex';
@@ -207,6 +209,7 @@ import { minValue, maxValue } from 'vuelidate/lib/validators';
 const isoTimeRegex = /^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$/;
 export default {
   name: 'RuntimeProcessorDiagnostic',
+  components: { InfoTooltip },
   mixins: [LoadingBarMixin, BVToastMixin, VuelidateMixin],
   props: {
     safeMode: {

--- a/src/views/ResourceManagement/SystemParameters/SystemParameters.vue
+++ b/src/views/ResourceManagement/SystemParameters/SystemParameters.vue
@@ -5,18 +5,6 @@
         <page-title :title="$t('appPageTitle.systemParameters')" />
       </b-col>
     </b-row>
-    <b-row>
-      <b-col md="8" xl="6">
-        <alert v-if="!isServerOff" variant="info" class="mb-4">
-          <div class="font-weight-bold">
-            {{ $t('pageSystemParameters.alert.title') }}
-          </div>
-          <div>
-            {{ $t('pageSystemParameters.alert.message') }}
-          </div>
-        </alert>
-      </b-col>
-    </b-row>
     <lateral-cast-out :is-server-off="isServerOff" />
     <frequency-cap :is-server-off="isServerOff" />
     <aggressive-prefetch :is-server-off="isServerOff" />
@@ -28,7 +16,6 @@
 import PageTitle from '@/components/Global/PageTitle';
 import BVToastMixin from '@/components/Mixins/BVToastMixin';
 import LoadingBarMixin from '@/components/Mixins/LoadingBarMixin';
-import Alert from '@/components/Global/Alert';
 import LateralCastOut from './LateralCastOut';
 import FrequencyCap from './FrequencyCap';
 import AggressivePrefetch from './AggressivePrefetch';
@@ -38,7 +25,6 @@ export default {
   name: 'SystemParameters',
   components: {
     PageTitle,
-    Alert,
     LateralCastOut,
     FrequencyCap,
     AggressivePrefetch,


### PR DESCRIPTION
- The Alert message in the page is removed as it does not apply to all the parameters.
- Added icons to the parameters(Lateral cast out, Frequency cap, Aggressive prefetch and RPD feature) for which addition information is required.