### PR TITLE
Added check for the readonly current user for the privilege dropdown display

### DIFF
--- a/src/views/SecurityAndAccess/UserManagement/ModalUser.vue
+++ b/src/views/SecurityAndAccess/UserManagement/ModalUser.vue
@@ -276,7 +276,9 @@ export default {
       return this.user?.RoleId !== 'OemIBMServiceAgent';
     },
     notReadyOnly() {
-      return this.user?.RoleId !== 'ReadOnly';
+      const cUser = this.$store.getters['global/currentUser'];
+      const RoleId = cUser.RoleId;
+      return RoleId !== 'ReadOnly';
     },
     accountSettings() {
       return this.$store.getters['userManagement/accountSettings'];


### PR DESCRIPTION
Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=566129
Description:
Privilege dropdown for readonly user should be present when modifying with administrative or service user login.
Screenshot:
When Logged in as Admin
<img width="953" alt="image" src="https://github.com/ibm-openbmc/webui-vue/assets/110152569/c46b7390-8e0e-4bf1-acf7-ac0f43b34332">
When Logged in as Service
<img width="930" alt="image" src="https://github.com/ibm-openbmc/webui-vue/assets/110152569/45f24fcc-39a3-4c9f-9eec-a297aec92f5c">
When logged in as a readonly 
<img width="960" alt="image" src="https://github.com/ibm-openbmc/webui-vue/assets/110152569/4c928d0d-a3ba-4c0e-8274-f84e22de472a">



