### PR TITLE
Updated Privilege options in User Management page

### DIFF
--- a/src/store/modules/SecurityAndAccess/UserManagementStore.js
+++ b/src/store/modules/SecurityAndAccess/UserManagementStore.js
@@ -155,12 +155,30 @@ const UserManagementStore = {
     },
     async updateUser(
       { dispatch },
-      { originalUsername, username, password, privilege, status, locked }
+      {
+        originalUsername,
+        currentUser,
+        username,
+        password,
+        privilege,
+        status,
+        locked,
+      }
     ) {
       const data = {};
+      const notReadOnly =
+        privilege !== 'ReadOnly' && currentUser.RoleId !== 'ReadOnly';
       if (username) data.UserName = username;
       if (password) data.Password = password;
-      if (privilege && privilege !== 'ReadOnly') data.RoleId = privilege;
+      if (privilege && notReadOnly) {
+        data.RoleId = privilege;
+      } else if (
+        privilege &&
+        privilege === 'ReadOnly' &&
+        currentUser.RoleId !== 'ReadOnly'
+      ) {
+        data.RoleId = privilege;
+      }
       if (status !== undefined) data.Enabled = status;
       if (locked !== undefined) data.Locked = locked;
       return await api

--- a/src/views/SecurityAndAccess/UserManagement/ModalUser.vue
+++ b/src/views/SecurityAndAccess/UserManagement/ModalUser.vue
@@ -278,6 +278,9 @@ export default {
     notReadyOnly() {
       return this.user?.RoleId !== 'ReadOnly';
     },
+    currentUser() {
+      return this.$store.getters['global/currentUser'];
+    },
     accountSettings() {
       return this.$store.getters['userManagement/accountSettings'];
     },
@@ -347,6 +350,7 @@ export default {
       } else {
         if (this.$v.$invalid) return;
         userData.originalUsername = this.originalUsername;
+        userData.currentUser = this.currentUser;
         if (this.$v.form.status.$dirty) {
           userData.status = this.form.status;
         }

--- a/src/views/SecurityAndAccess/UserManagement/ModalUser.vue
+++ b/src/views/SecurityAndAccess/UserManagement/ModalUser.vue
@@ -276,7 +276,9 @@ export default {
       return this.user?.RoleId !== 'OemIBMServiceAgent';
     },
     notReadyOnly() {
-      return this.user?.RoleId !== 'ReadOnly';
+      const cUser = this.$store.getters['global/currentUser'];
+      const RoleId = cUser.RoleId;
+      return RoleId !== 'ReadOnly';
     },
     currentUser() {
       return this.$store.getters['global/currentUser'];


### PR DESCRIPTION
Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=566104
https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=566129
Description: 
Added check for the read-only current user for the privilege dropdown display and also check for privilege as read-only and user as read-only for privilege change when logged in with Admin/Service
github: https://github.com/ibm-openbmc/openbmc/issues/288
Screenshot: 
Admin4 with Admin privilege with service login
<img width="958" alt="image" src="https://github.com/ibm-openbmc/webui-vue/assets/110152569/b620bb86-8557-4f4d-abd2-4273c6af90f7">
Admin4 changed to read-only privilege  with service login
<img width="960" alt="image" src="https://github.com/ibm-openbmc/webui-vue/assets/110152569/35a0ab1d-fb7f-480f-9f27-b5e552e39a10">
When Logged as Admin:
![image](https://github.com/ibm-openbmc/webui-vue/assets/110152569/0a8df0ff-b6e1-402e-bd1d-be2362a3a181)
When Logged as Service
![image](https://github.com/ibm-openbmc/webui-vue/assets/110152569/eb81b8f6-6981-420b-b9bd-ec29f0a7b22f)
When Logged as Read-only
![image](https://github.com/ibm-openbmc/webui-vue/assets/110152569/118c91b1-5f95-4b95-9699-b323a4e238dd)


