### PR TITLE
Added condition check for manual and normal modes for displaying prompt

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -1486,6 +1486,7 @@
       "pvm_system_operating_mode": "Server operating mode",
       "pvm_system_power_off_policy": "Server power policy",
       "selectedOperatingModeManual": "On save operating mode will be set to Manual",
+      "selectedOperatingModeNormal":  "On save operating mode will be set to Normal",
       "serverFirmware": "Server firmware start policy",
       "powerSettingDescription": "View power setting descriptions",
       "stayOn": "Stay On",

--- a/src/views/Operations/ServerPowerOperations/BiosSettings.vue
+++ b/src/views/Operations/ServerPowerOperations/BiosSettings.vue
@@ -72,6 +72,7 @@
                 <b-col
                   v-if="
                     selectedOperatingMode &&
+                    selectedOperatingMode === manualMode &&
                     selectedOperatingMode !== currentOperatingMode
                   "
                   sm="5"
@@ -88,6 +89,49 @@
                       {{
                         $t(
                           'pageServerPowerOperations.biosSettings.selectedOperatingModeManual'
+                        )
+                      }}
+                    </p>
+                  </alert>
+                  <div>
+                    <b-link to="/settings/power-restore-policy">
+                      {{ $t(`appPageTitle.powerRestorePolicy`) }}
+                    </b-link>
+                    {{
+                      $t(
+                        `pageServerPowerOperations.biosSettings.powPolicySection`,
+                        {
+                          powerPolicy:
+                            powerPolicy === 'AlwaysOff'
+                              ? $t(`pagePowerRestorePolicy.policies.AlwaysOff`)
+                              : powerPolicy === 'AlwaysOn'
+                              ? $t(`pagePowerRestorePolicy.policies.AlwaysOn`)
+                              : $t(`pagePowerRestorePolicy.policies.LastState`),
+                        }
+                      )
+                    }}
+                  </div>
+                </b-col>
+                <b-col
+                  v-else-if="
+                    selectedOperatingMode &&
+                    selectedOperatingMode === normalMode &&
+                    selectedOperatingMode !== currentOperatingMode
+                  "
+                  sm="5"
+                >
+                  <alert variant="info" class="mb-4">
+                    <p>
+                      {{
+                        $t(
+                          'pageServerPowerOperations.biosSettings.currentOperatingModeManual'
+                        )
+                      }}
+                    </p>
+                    <p>
+                      {{
+                        $t(
+                          'pageServerPowerOperations.biosSettings.selectedOperatingModeNormal'
                         )
                       }}
                     </p>


### PR DESCRIPTION
Github issue: https://github.com/ibm-openbmc/openbmc/issues/293
Description: In manual mode when select normal mode the prompt is giving the incorrect statements.
1. Added separate prompts for both manual and normal.
Screenshot: 
<img width="802" alt="image" src="https://github.com/ibm-openbmc/webui-vue/assets/110152569/99475ba8-26d2-420e-9117-6ea0770bdb55">
<img width="841" alt="image" src="https://github.com/ibm-openbmc/webui-vue/assets/110152569/24e435f3-7e8b-4177-ae87-b0aa7f908699">

