### PR TITLE
Implemented new logic for I/O slots

### DIFF
--- a/src/store/modules/HardwareStatus/PcieTopologyStore.js
+++ b/src/store/modules/HardwareStatus/PcieTopologyStore.js
@@ -761,6 +761,7 @@ const PcieTopologyStore = {
                             ) {
                               cablesData.detailedInfo.downstreamPorts.push({
                                 data: element?.portsData[m],
+                                grandParent: element.data,
                                 grandParentLocation:
                                   element.data?.Location?.PartLocation
                                     ?.ServiceLabel,
@@ -792,6 +793,7 @@ const PcieTopologyStore = {
                             ) {
                               cablesData.detailedInfo.downstreamPorts.push({
                                 data: dpResponse.data,
+                                grandParent: chassisResp.data,
                                 grandParentLocation:
                                   chassisResp.data?.Location?.PartLocation
                                     ?.ServiceLabel,
@@ -1027,13 +1029,14 @@ const PcieTopologyStore = {
                         cable.detailedInfo.downstreamChassis[0].pcieSlots.map(
                           (dsSlot) => {
                             if (
-                              dsSlot?.data?.Location?.PartLocation?.ServiceLabel
+                              dsSlot?.data?.Links?.Oem?.IBM
+                                ?.UpstreamFabricAdapter
                             ) {
                               if (
-                                dsSlot?.data?.Location?.PartLocation?.ServiceLabel.startsWith(
-                                  cable.detailedInfo?.downstreamPorts[0]
-                                    ?.grandParentLocation
-                                )
+                                dsSlot?.data?.Links?.Oem?.IBM
+                                  ?.UpstreamFabricAdapter['@odata.id'] ===
+                                cable.detailedInfo?.downstreamPorts[0]
+                                  ?.grandParent['@odata.id']
                               ) {
                                 const duplicate = row.ioSlotLocation.find(
                                   (obj) => {


### PR DESCRIPTION
- Previously, we were comparing the slot's location number with the downstream adapter's location number and then pushing them to the I/O Slots list, Now we are comparing upstream fabric adapter with downstream adapter and pushing them to the list.
- Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=481314