### PR TITLE
Filtering the IP address in HMC and user sessions

### DIFF
--- a/src/store/modules/SecurityAndAccess/SessionsStore.js
+++ b/src/store/modules/SecurityAndAccess/SessionsStore.js
@@ -26,11 +26,9 @@ const SessionsStore = {
         .then((sessionUris) => {
           const allConnectionsData = sessionUris.map((sessionUri) => {
             //For filtering IP address to IPv4
-            let filteredIPAddress = sessionUri.data?.ClientOriginIPAddress.includes(
-              '::ffff'
-            )
-              ? sessionUri.data?.ClientOriginIPAddress.slice(7)
-              : sessionUri.data?.ClientOriginIPAddress;
+            let filteredIPAddress = sessionUri.data?.ClientOriginIPAddress.split(
+              '::ffff:'
+            ).pop();
             return {
               clientID: sessionUri.data?.Context,
               username: sessionUri.data?.UserName,


### PR DESCRIPTION
- Using split() and pop() to filter the IP address in the HMC and user sessions page.
- Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=570310