### PR TITLE
Enabled edit and delete for Link Local addresses

### DIFF
--- a/src/views/Settings/Network/TableIpv4.vue
+++ b/src/views/Settings/Network/TableIpv4.vue
@@ -163,16 +163,12 @@ export default {
           actions: [
             {
               value: 'edit',
-              enabled:
-                ipv4.AddressOrigin !== 'IPv4LinkLocal' &&
-                ipv4.AddressOrigin !== 'DHCP',
+              enabled: ipv4.AddressOrigin !== 'DHCP',
               title: this.$t('pageNetwork.table.editIpv4'),
             },
             {
               value: 'delete',
-              enabled:
-                ipv4.AddressOrigin !== 'IPv4LinkLocal' &&
-                ipv4.AddressOrigin !== 'DHCP',
+              enabled: ipv4.AddressOrigin !== 'DHCP',
               title: this.$t('pageNetwork.table.deleteIpv4'),
             },
           ],

--- a/src/views/Settings/Network/TableIpv6.vue
+++ b/src/views/Settings/Network/TableIpv6.vue
@@ -199,7 +199,6 @@ export default {
             {
               value: 'edit',
               enabled:
-                ipv6.AddressOrigin !== 'LinkLocal' &&
                 ipv6.AddressOrigin !== 'DHCPv6' &&
                 ipv6.AddressOrigin !== 'SLAAC',
               title: this.$t('pageNetwork.table.editIpv6'),
@@ -207,7 +206,6 @@ export default {
             {
               value: 'delete',
               enabled:
-                ipv6.AddressOrigin !== 'LinkLocal' &&
                 ipv6.AddressOrigin !== 'DHCPv6' &&
                 ipv6.AddressOrigin !== 'SLAAC',
               title: this.$t('pageNetwork.table.deleteIpv6'),


### PR DESCRIPTION
 - Edit and delete options for Link Local addresses were disabled previously, Enabled them in this change.
 - Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=574113