### PR TITLE
 server power policy:  disabled the server power options on save and enabled on successful save

### DIFF
--- a/src/views/Operations/ServerPowerOperations/BiosSettings.vue
+++ b/src/views/Operations/ServerPowerOperations/BiosSettings.vue
@@ -149,6 +149,7 @@
                     v-model="attributeKeys[key]"
                     :value="values.value"
                     :aria-describedby="values.value"
+                    :disabled="disabled"
                   >
                     <template v-if="values.value === 'Power Off'">{{
                       $t('pageServerPowerOperations.biosSettings.powerOff')
@@ -276,6 +277,10 @@ export default {
     attributeValues: {
       type: Object,
       default: null,
+    },
+    disabled: {
+      type: Boolean,
+      require: true,
     },
   },
   data() {

--- a/src/views/Operations/ServerPowerOperations/BootSettings.vue
+++ b/src/views/Operations/ServerPowerOperations/BootSettings.vue
@@ -4,6 +4,7 @@
       v-if="form.attributes && form.attributeValues"
       :key="componentKey"
       :attribute-values="form.attributeValues"
+      :disabled="disabled"
       @updated-attributes="updateAttributeKeys"
     />
     <b-button variant="primary" type="submit" class="mb-3">
@@ -33,6 +34,9 @@ export default {
   },
   computed: {
     ...mapState('serverBootSettings', ['attributeValues', 'biosAttributes']),
+    disabled() {
+      return this.$store.getters['serverBootSettings/disabled'];
+    },
   },
   watch: {
     attributeValues: function (value) {
@@ -46,7 +50,7 @@ export default {
     Promise.all([
       this.$store.dispatch('serverBootSettings/getBiosAttributes'),
       this.$store.dispatch('serverBootSettings/getAttributeValues'),
-    ]).finally(() =>
+    ]).finally(
       this.$root.$emit('server-power-operations-boot-settings-complete')
     );
   },
@@ -65,7 +69,9 @@ export default {
           this.componentKey += 1;
           this.successToast(message);
         })
-        .catch(({ message }) => this.errorToast(message))
+        .catch(({ message }) => {
+          this.errorToast(message);
+        })
         .finally(() => {
           this.endLoader();
         });


### PR DESCRIPTION
github issue: https://github.com/ibm-openbmc/openbmc/issues/291
Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=575528
Description: disabled the server power options on save and enabled on successful save