### PR TITLE
1030: Enabled edit and delete for Link Local addresses

### DIFF
--- a/src/store/modules/Settings/NetworkStore.js
+++ b/src/store/modules/Settings/NetworkStore.js
@@ -233,7 +233,11 @@ const NetworkStore = {
           `/redfish/v1/Managers/bmc/EthernetInterfaces/${state.selectedInterfaceId}`,
           updatedIpv4Array
         )
-        .then(dispatch('getEthernetData'))
+        .then(() => {
+          setTimeout(() => {
+            dispatch('getEthernetData');
+          }, 10000);
+        })
         .then(() => {
           return i18n.t('pageNetwork.toast.successSaveNetworkSettings', {
             setting: i18n.t('pageNetwork.ipv4'),

--- a/src/views/Settings/Network/Network.vue
+++ b/src/views/Settings/Network/Network.vue
@@ -144,16 +144,32 @@ export default {
         const editRow = modalData.concat(selectedRow);
         this.$store
           .dispatch('network/updateIpv4Address', editRow)
-          .then((message) => this.successToast(message))
-          .catch(({ message }) => this.errorToast(message))
-          .finally(() => this.endLoader());
+          .then((message) => {
+            this.startLoader();
+            this.successToast(message);
+            setTimeout(() => {
+              this.endLoader();
+            }, 10000);
+          })
+          .catch(({ message }) => {
+            this.errorToast(message);
+            this.endLoader();
+          });
       } else {
         // Add new address
         this.$store
           .dispatch('network/updateIpv4Address', modalData)
-          .then((message) => this.successToast(message))
-          .catch(({ message }) => this.errorToast(message))
-          .finally(() => this.endLoader());
+          .then((message) => {
+            this.startLoader();
+            this.successToast(message);
+            setTimeout(() => {
+              this.endLoader();
+            }, 10000);
+          })
+          .catch(({ message }) => {
+            this.errorToast(message);
+            this.endLoader();
+          });
       }
     },
     saveDnsAddress(modalFormData) {

--- a/src/views/Settings/Network/TableIpv4.vue
+++ b/src/views/Settings/Network/TableIpv4.vue
@@ -255,16 +255,12 @@ export default {
           actions: [
             {
               value: 'edit',
-              enabled:
-                ipv4.AddressOrigin !== 'IPv4LinkLocal' &&
-                ipv4.AddressOrigin !== 'DHCP',
+              enabled: ipv4.AddressOrigin !== 'DHCP',
               title: this.$t('pageNetwork.table.editIpv4'),
             },
             {
               value: 'delete',
-              enabled:
-                ipv4.AddressOrigin !== 'IPv4LinkLocal' &&
-                ipv4.AddressOrigin !== 'DHCP',
+              enabled: ipv4.AddressOrigin !== 'DHCP',
               title: this.$t('pageNetwork.table.deleteIpv4'),
             },
           ],


### PR DESCRIPTION
  - Edit and delete options for Link Local addresses were disabled previously, Enabled them in this change.
  - Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=574113