### PR TITLE
Added delay to get the updated SLAAC address

### DIFF
--- a/src/store/modules/Settings/NetworkStore.js
+++ b/src/store/modules/Settings/NetworkStore.js
@@ -292,7 +292,14 @@ const NetworkStore = {
           `/redfish/v1/Managers/bmc/EthernetInterfaces/${state.selectedInterfaceId}`,
           data
         )
-        .then(dispatch('getEthernetData'))
+        .then(() => {
+          // Getting Ethernet data here so that the toggle gets updated
+          dispatch('getEthernetData');
+          setTimeout(() => {
+            // Getting Ethernet data here so that the IPv6 table gets updated
+            dispatch('getEthernetData');
+          }, 10000);
+        })
         .then(() => {
           return i18n.t('pageNetwork.toast.successSaveNetworkSettings', {
             setting: i18n.t('pageNetwork.ipv6AutoConfig'),

--- a/src/views/Settings/Network/TableIpv6.vue
+++ b/src/views/Settings/Network/TableIpv6.vue
@@ -28,6 +28,7 @@
                 id="ipv6AutoConfigSwitch"
                 v-model="ipv6AutoConfigState"
                 switch
+                :disabled="!isAutoConfigLoaded"
                 @change="changeIpv6AutoConfigState"
               >
                 <span v-if="ipv6AutoConfigState">
@@ -109,6 +110,7 @@ export default {
   },
   data() {
     return {
+      isAutoConfigLoaded: true,
       form: {
         ipv6TableItems: [],
       },
@@ -273,12 +275,21 @@ export default {
         .catch(({ message }) => this.errorToast(message));
     },
     changeIpv6AutoConfigState(state) {
+      this.isAutoConfigLoaded = false;
       this.$store
         .dispatch('network/saveIpv6AutoConfigState', state)
         .then((success) => {
+          this.startLoader();
           this.successToast(success);
+          setTimeout(() => {
+            this.isAutoConfigLoaded = true;
+            this.endLoader();
+          }, 10000);
         })
-        .catch(({ message }) => this.errorToast(message));
+        .catch(({ message }) => {
+          this.isAutoConfigLoaded = true;
+          this.errorToast(message);
+        });
     },
   },
 };


### PR DESCRIPTION
-  Added 10 seconds delay in getting the latest values from the redfish response as it would take some time to update in the redfish. We were trying to get the values from the table immediately after update, causing this issue.

- Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=575830