### PR TITLE
Removed pel id and replaced with event id

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -458,6 +458,7 @@
       "locationCode": "Location Code",
       "name": "Name",
       "pelId": "Pel ID",
+      "eventId": "Event ID",
       "settings": "Settings",
       "size": "Size in mebibytes"
     }

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -498,6 +498,7 @@
       "id": "Id",
       "name": "Name",
       "pelId": "Pel Id",
+      "eventId": "Event ID",
       "reference": "Reference",
       "resource": "Resource",
       "severity": "Severity",

--- a/src/store/modules/Logs/DeconfigurationRecordsStore.js
+++ b/src/store/modules/Logs/DeconfigurationRecordsStore.js
@@ -82,7 +82,7 @@ const DeconfigurationRecordsStore = {
                 uri: log['@odata.id'],
                 severity: Severity,
                 location: LocationCode,
-                EventID: eventId,
+                eventID: eventId,
               };
             })
           );

--- a/src/store/modules/Logs/DeconfigurationRecordsStore.js
+++ b/src/store/modules/Logs/DeconfigurationRecordsStore.js
@@ -61,11 +61,11 @@ const DeconfigurationRecordsStore = {
                   : null,
                 LocationCode,
               } = log;
-              let pelId = '';
+              let eventId = '';
               const additionalDataURIValue = log.AdditionalDataURI;
               if (additionalDataURIValue) {
                 const splitUrl = additionalDataURIValue.split('/');
-                pelId = splitUrl[splitUrl.length - 2];
+                eventId = splitUrl[splitUrl.length - 2];
               }
               return {
                 additionalDataUri: AdditionalDataURI,
@@ -82,7 +82,7 @@ const DeconfigurationRecordsStore = {
                 uri: log['@odata.id'],
                 severity: Severity,
                 location: LocationCode,
-                pelID: pelId,
+                EventID: eventId,
               };
             })
           );

--- a/src/store/modules/Settings/HardwareDeconfigurationStore.js
+++ b/src/store/modules/Settings/HardwareDeconfigurationStore.js
@@ -59,7 +59,7 @@ const HardwareDeconfigurationStore = {
         api.spread((...responses) => {
           const coreData = responses.map(({ data }) => {
             var msgArgs = 'None';
-            var pelId = '';
+            var eventId = '';
             const conditionsArray = data.Status?.Conditions;
             if (Array.isArray(conditionsArray) && conditionsArray.length) {
               const messageArgsArray = conditionsArray[0].MessageArgs;
@@ -68,9 +68,9 @@ const HardwareDeconfigurationStore = {
               }
               const logEntry = conditionsArray[0].LogEntry;
               if (logEntry) {
-                const pelIdUrl = logEntry['@odata.id'];
-                const splitUrl = pelIdUrl.split('/');
-                pelId = splitUrl[splitUrl.length - 1];
+                const eventIdUrl = logEntry['@odata.id'];
+                const splitUrl = eventIdUrl.split('/');
+                eventId = splitUrl[splitUrl.length - 1];
               }
             }
             return {
@@ -110,7 +110,7 @@ const HardwareDeconfigurationStore = {
                   ? i18n.t('pageDeconfigurationHardware.table.filter.unknown')
                   : msgArgs,
               processorId: procId,
-              pelID: pelId,
+              eventID: eventId,
             };
           });
           return coreData;
@@ -134,7 +134,7 @@ const HardwareDeconfigurationStore = {
         api.spread((...responses) => {
           const dimmsData = responses.map(({ data }) => {
             var msgArgs = 'None';
-            var pelId = '';
+            var eventId = '';
             const conditionsArray = data.Status?.Conditions;
             if (Array.isArray(conditionsArray) && conditionsArray.length) {
               const messageArgsArray = conditionsArray[0].MessageArgs;
@@ -143,9 +143,9 @@ const HardwareDeconfigurationStore = {
               }
               const logEntry = conditionsArray[0].LogEntry;
               if (logEntry) {
-                const pelIdUrl = logEntry['@odata.id'];
-                const splitUrl = pelIdUrl.split('/');
-                pelId = splitUrl[splitUrl.length - 1];
+                const eventIdUrl = logEntry['@odata.id'];
+                const splitUrl = eventIdUrl.split('/');
+                eventId = splitUrl[splitUrl.length - 1];
               }
             }
             return {
@@ -184,7 +184,7 @@ const HardwareDeconfigurationStore = {
               settings: data.Enabled,
               uri: data['@odata.id'],
               available: data.Status?.State,
-              pelID: pelId,
+              eventID: eventId,
             };
           });
           const dimmsDataFiltered = dimmsData.filter(

--- a/src/views/Logs/DeconfigurationRecords/DeconfigurationRecords.vue
+++ b/src/views/Logs/DeconfigurationRecords/DeconfigurationRecords.vue
@@ -272,8 +272,8 @@ export default {
           sortable: true,
         },
         {
-          key: 'pelID',
-          label: this.$t('pageDeconfigurationRecords.table.pelId'),
+          key: 'EventID',
+          label: this.$t('pageDeconfigurationRecords.table.eventId'),
           sortable: true,
         },
         {

--- a/src/views/Logs/DeconfigurationRecords/DeconfigurationRecords.vue
+++ b/src/views/Logs/DeconfigurationRecords/DeconfigurationRecords.vue
@@ -272,7 +272,7 @@ export default {
           sortable: true,
         },
         {
-          key: 'EventID',
+          key: 'eventID',
           label: this.$t('pageDeconfigurationRecords.table.eventId'),
           sortable: true,
         },

--- a/src/views/Settings/HardwareDeconfiguration/MemoryDimms.vue
+++ b/src/views/Settings/HardwareDeconfiguration/MemoryDimms.vue
@@ -151,10 +151,10 @@ export default {
           tdClass: 'text-nowrap',
         },
         {
-          key: 'pelID',
+          key: 'eventID',
           sortable: true,
           formatter: this.dataFormatter,
-          label: this.$t('pageDeconfigurationHardware.table.pelId'),
+          label: this.$t('pageDeconfigurationHardware.table.eventId'),
         },
         {
           key: 'deconfigurationType',

--- a/src/views/Settings/HardwareDeconfiguration/ProcessorCores.vue
+++ b/src/views/Settings/HardwareDeconfiguration/ProcessorCores.vue
@@ -166,10 +166,10 @@ export default {
           tdClass: 'text-nowrap',
         },
         {
-          key: 'pelID',
+          key: 'eventID',
           sortable: true,
           formatter: this.dataFormatter,
-          label: this.$t('pageDeconfigurationHardware.table.pelId'),
+          label: this.$t('pageDeconfigurationHardware.table.eventId'),
           tdClass: 'text-nowrap',
         },
         {


### PR DESCRIPTION
Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=576103
Description: On the hardware deconfiguration page of the BMC GUI the PEL ID column is renamed or "Event ID" since that is what is listed in that column.