### PR TITLE
Rearranged Local port location

### DIFF
--- a/src/store/modules/HardwareStatus/PcieTopologyStore.js
+++ b/src/store/modules/HardwareStatus/PcieTopologyStore.js
@@ -722,6 +722,7 @@ const PcieTopologyStore = {
             row.linkType = 'Primary';
             row.linkSpeed = 'unknown';
             row.linkWidth = 'unknown';
+            let tempLocalPorts = [];
             row.localPortLocation = [];
             row.remotePortLocation = [];
             row.ioSlotLocation = [];
@@ -1033,6 +1034,34 @@ const PcieTopologyStore = {
                     }
                   }
                 });
+              }
+              if (
+                row?.localPortLocation.length > 0 &&
+                row?.remotePortLocation.length > 0
+              ) {
+                if (
+                  cable.detailedInfo?.upstreamPorts.length > 0 &&
+                  cable.detailedInfo?.downstreamPorts.length > 0
+                ) {
+                  row?.remotePortLocation.map((remotePort, index) => {
+                    if (
+                      remotePort.locationNumber ===
+                      cable.detailedInfo?.downstreamPorts[0].data.Location
+                        ?.PartLocation?.ServiceLabel
+                    ) {
+                      tempLocalPorts[index] = {
+                        locationIndicatorActive:
+                          cable.detailedInfo?.upstreamPorts[0]
+                            .LocationIndicatorActive,
+                        locationNumber:
+                          cable.detailedInfo?.upstreamPorts[0].Location
+                            ?.PartLocation?.ServiceLabel,
+                        uri: cable.detailedInfo?.upstreamPorts[0]['@odata.id'],
+                      };
+                    }
+                  });
+                  row.localPortLocation = tempLocalPorts;
+                }
               }
             });
             fabricAdapterInfo.map((adapter) => {


### PR DESCRIPTION
- Local port location was not matching with the corresponding remote port location. This has been arranged in the right order.
- Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=564519