### PR TITLE
Load Navigation Items after checking model type

### DIFF
--- a/src/components/AppNavigation/AppNavigation.vue
+++ b/src/components/AppNavigation/AppNavigation.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div v-if="modelType !== '--'">
     <div class="nav-container" :class="{ open: isNavigationOpen }">
       <nav ref="nav" :aria-label="$t('appNavigation.primaryNavigation')">
         <b-nav vertical class="mb-4">
@@ -70,6 +70,9 @@ export default {
     };
   },
   computed: {
+    modelType() {
+      return this.$store?.getters['global/modelType'];
+    },
     currentUser() {
       return this.$store?.getters['global/currentUser'];
     },


### PR DESCRIPTION
- Seems that both the Nav Items and model type is checked simultaneously, sometimes might miss Concurrent maintenance page to be listed. Now, we would not display the Nav items until the model is updated. 