### PR TITLE
Added HMC managed check for System Memory Reserved for KVM Guest Mgmt

### DIFF
--- a/src/views/Operations/ServerPowerOperations/BiosSettings.vue
+++ b/src/views/Operations/ServerPowerOperations/BiosSettings.vue
@@ -256,8 +256,9 @@
         </b-col>
         <b-col
           v-if="
-            attributeKeys[key] === 'Linux KVM' ||
-            attributeKeys[key] === 'Default'
+            !isHmcManaged() &&
+            (attributeKeys[key] === 'Linux KVM' ||
+              attributeKeys[key] === 'Default')
           "
           :key="key + 1"
           sm="8"


### PR DESCRIPTION
- Linux KVM percentage was being displayed for HMC Managed system, Fixed that in this change.