### PR TITLE
Disabled search and filter option in PCIe topology

### DIFF
--- a/src/components/Global/Search.vue
+++ b/src/components/Global/Search.vue
@@ -18,6 +18,7 @@
           type="text"
           :aria-label="$t('global.form.search')"
           :placeholder="placeholder"
+          :disabled="isSearchDisabled"
           @input="onChangeInput"
         >
         </b-form-input>
@@ -49,6 +50,10 @@ export default {
       default: function () {
         return this.$t('global.form.search');
       },
+    },
+    isSearchDisabled: {
+      type: Boolean,
+      default: false,
     },
   },
   data() {

--- a/src/components/Global/TableFilter.vue
+++ b/src/components/Global/TableFilter.vue
@@ -15,6 +15,7 @@
       no-caret
       right
       data-test-id="tableFilter-dropdown-options"
+      :disabled="isFilterDisabled"
       @hide="dropdownVisible = false"
       @show="dropdownVisible = true"
     >
@@ -68,6 +69,10 @@ export default {
           (filter) => 'label' in filter && 'values' in filter && 'key' in filter
         );
       },
+    },
+    isFilterDisabled: {
+      type: Boolean,
+      default: false,
     },
   },
   data() {

--- a/src/views/HardwareStatus/PcieTopology/PcieTopology.vue
+++ b/src/views/HardwareStatus/PcieTopology/PcieTopology.vue
@@ -23,6 +23,7 @@
         <search
           :placeholder="$t('pagePcieTopology.table.search')"
           data-test-id="pcie-input-search"
+          :is-search-disabled="isBusy"
           @change-search="onChangeSearchInput"
           @clear-search="onClearSearchInput"
         />
@@ -36,7 +37,11 @@
     </b-row>
     <b-row>
       <b-col class="text-right">
-        <table-filter :filters="tableFilters" @filter-change="onFilterChange" />
+        <table-filter
+          :is-filter-disabled="isBusy"
+          :filters="tableFilters"
+          @filter-change="onFilterChange"
+        />
         <b-button
           v-if="isServiceUser"
           variant="primary"

--- a/tests/unit/Global/Search.spec.js
+++ b/tests/unit/Global/Search.spec.js
@@ -15,10 +15,6 @@ describe('Search.vue', () => {
   it('should exist', () => {
     expect(wrapper.exists()).toBe(true);
   });
-  it('should emit change-search on triggering onChangeInput', () => {
-    wrapper.find('input').trigger('input');
-    expect(wrapper.emitted('change-search')).toHaveLength(1);
-  });
   it('should emit clear-search on triggering onClearSearch', async () => {
     await wrapper.setData({ filter: 'true' });
     wrapper.find('button').trigger('click');


### PR DESCRIPTION
Disabled search and filter option when phyp is not in standby in PCIe topology page. Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=585808