### PR TITLE
Updated Linux KVM implementation

### DIFF
--- a/src/views/Operations/ServerPowerOperations/BiosSettings.vue
+++ b/src/views/Operations/ServerPowerOperations/BiosSettings.vue
@@ -10,15 +10,7 @@
           "
           :key="key"
           sm="8"
-          :xl="
-            attributeKeys.pvm_default_os_type === 'Linux KVM' &&
-            key === 'pvm_linux_kvm_memory'
-              ? 5
-              : attributeKeys.pvm_default_os_type === 'Default' &&
-                key === 'pvm_rpa_boot_mode'
-              ? 5
-              : 6
-          "
+          xl="6"
         >
           <b-form-group
             v-if="
@@ -254,53 +246,63 @@
             </b-form-group>
           </div>
         </b-col>
-        <b-col
-          v-if="
-            !isHmcManaged() &&
-            (attributeKeys[key] === 'Linux KVM' ||
-              attributeKeys[key] === 'Default')
-          "
-          :key="key + 1"
-          sm="8"
-          xl="7"
-        >
-          <b-form-group
-            label-for="linux_kvm_percentage"
-            class="mb-4"
-            :label="
-              $t(
-                `${'pageServerPowerOperations.biosSettings.pvm_linux_kvm_percentage'}`
-              )
-            "
-          >
-            <b-form-input
-              id="linux_kvm_percentage"
-              v-model="linuxKvmPercentageValue"
-              type="number"
-              :disabled="attributeKeys.pvm_linux_kvm_memory === 'Automatic'"
-              step="0.1"
-              min="0.0"
-              max="100.0"
-              @keypress="validateLinuxKvmPercentage"
-              @input="changeLinuxKvmPercentageValue"
-            />
-            <span
-              v-if="
-                linuxKvmPercentageValue < 0.0 ||
-                linuxKvmPercentageValue > 100.0 ||
-                !isLinuxKvmValid
-              "
-              class="error-text"
-            >
-              {{
-                $t(
-                  'pageServerPowerOperations.biosSettings.linuxKvmPercentage.errorMessage'
-                )
-              }}
-            </span>
-          </b-form-group>
-        </b-col>
       </template>
+    </b-row>
+    <b-row>
+      <b-col
+        v-if="
+          !isHmcManaged() &&
+          attributeKeys['pvm_default_os_type'] === 'Linux KVM'
+        "
+        key="percentage"
+        sm="8"
+        xl="6"
+      >
+        <b-form-group
+          label-for="linux_kvm_percentage"
+          class="mb-4"
+          :label="
+            $t(
+              `${'pageServerPowerOperations.biosSettings.pvm_linux_kvm_percentage'}`
+            )
+          "
+        >
+          <b-form-input
+            v-if="
+              attributeKeys.pvm_linux_kvm_memory === 'Automatic' &&
+              linuxKvmPercentageValue === 0
+            "
+            value="--"
+            disabled
+          ></b-form-input>
+          <b-form-input
+            v-else
+            id="linux_kvm_percentage"
+            v-model="linuxKvmPercentageValue"
+            type="number"
+            :disabled="attributeKeys.pvm_linux_kvm_memory === 'Automatic'"
+            step="0.1"
+            min="0.0"
+            max="100.0"
+            @keypress="validateLinuxKvmPercentage"
+            @input="changeLinuxKvmPercentageValue"
+          />
+          <span
+            v-if="
+              linuxKvmPercentageValue < 0.0 ||
+              linuxKvmPercentageValue > 100.0 ||
+              !isLinuxKvmValid
+            "
+            class="error-text"
+          >
+            {{
+              $t(
+                'pageServerPowerOperations.biosSettings.linuxKvmPercentage.errorMessage'
+              )
+            }}
+          </span>
+        </b-form-group>
+      </b-col>
     </b-row>
     <b-row class="mb-3">
       <b-col xl="10">
@@ -750,10 +752,7 @@ export default {
           defaultPartitionEnvironment === 'Linux KVM'
         );
       } else if (key === 'pvm_linux_kvm_memory') {
-        return (
-          defaultPartitionEnvironment === 'Default' ||
-          defaultPartitionEnvironment === 'Linux KVM'
-        );
+        return defaultPartitionEnvironment === 'Linux KVM';
       } else {
         return true;
       }

--- a/src/views/Operations/ServerPowerOperations/BootSettings.vue
+++ b/src/views/Operations/ServerPowerOperations/BootSettings.vue
@@ -14,8 +14,7 @@
       class="mb-3"
       :disabled="
         !isLinuxKvmValid
-          ? form.attributes.pvm_default_os_type === 'Linux KVM' ||
-            form.attributes.pvm_default_os_type === 'Default'
+          ? form.attributes.pvm_default_os_type === 'Linux KVM'
             ? true
             : false
           : false
@@ -84,10 +83,7 @@ export default {
         .dispatch('serverBootSettings/saveSettings', settings)
         .then((message) => {
           this.componentKey += 1;
-          if (
-            settings.biosSettings.pvm_default_os_type == 'Linux KVM' ||
-            settings.biosSettings.pvm_default_os_type == 'Default'
-          ) {
+          if (settings.biosSettings.pvm_default_os_type == 'Linux KVM') {
             this.successToast(
               this.$t(
                 'pageServerPowerOperations.toast.successSaveLinuxKvmSettings'


### PR DESCRIPTION
- Displaying '--' when Automatic is selected and 0% is linux_kvm_percentage value.
- Only displaying when Linux KVM is Default partition environment.
- Moving the System Memory Reserved for KVM Guest Management (%) below Linux KVM dropdown for better user experience.
- Defects: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=593207,
https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=589124
