### PR TITLE
Disabled horizontal scroll bar on Notices page

### DIFF
--- a/src/views/Notices/Notices.vue
+++ b/src/views/Notices/Notices.vue
@@ -1,7 +1,7 @@
 <template>
   <b-container fluid="xl">
     <page-title />
-    <notices-text></notices-text>
+    <notices-text class="notice"></notices-text>
   </b-container>
 </template>
 
@@ -13,3 +13,10 @@ export default {
   components: { NoticesText, PageTitle },
 };
 </script>
+
+<style scoped>
+.notice {
+  overflow-x: hidden;
+  white-space: break-spaces;
+}
+</style>


### PR DESCRIPTION
- Disabled horizontal scroll bar on Notices page.
- Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=585809