### PR TITLE
Disabled the selection till save is success for bios setting

### DIFF
--- a/src/store/modules/Operations/BootSettingsStore.js
+++ b/src/store/modules/Operations/BootSettingsStore.js
@@ -175,7 +175,7 @@ const BootSettingsStore = {
           Attributes: biosSettings,
         })
         .then((response) => {
-          dispatch('saveOperatingModeSettings');
+          dispatch('saveOperatingModeSettings', biosSettings);
           return response;
         })
         .catch((error) => {
@@ -199,7 +199,7 @@ const BootSettingsStore = {
           );
         });
     },
-    saveOperatingModeSettings({ dispatch, commit }) {
+    saveOperatingModeSettings({ commit }, biosSettings) {
       return api
         .patch('/redfish/v1/Systems/system', {
           PowerRestorePolicy: this.state.serverBootSettings
@@ -211,7 +211,7 @@ const BootSettingsStore = {
           },
         })
         .then((response) => {
-          dispatch('getBiosAttributes');
+          commit('setBiosAttributes', biosSettings);
           return response;
         })
         .catch((error) => {

--- a/src/store/modules/Operations/BootSettingsStore.js
+++ b/src/store/modules/Operations/BootSettingsStore.js
@@ -248,6 +248,7 @@ const BootSettingsStore = {
         })
         .then((response) => {
           dispatch('saveOperatingModeSettings', biosSettings);
+          commit('setDisabled', false);
           return response;
         })
         .catch((error) => {

--- a/src/views/Operations/ServerPowerOperations/BiosSettings.vue
+++ b/src/views/Operations/ServerPowerOperations/BiosSettings.vue
@@ -26,7 +26,6 @@
               id="bios-option-sysOp-mode"
               v-model="attributeKeys[key]"
               :options="attriValuesArr"
-              :disabled="disabled"
             >
             </b-form-select>
           </b-form-group>
@@ -59,7 +58,6 @@
                     v-model="attributeKeys[key]"
                     :value="values.value"
                     :aria-describedby="values.value"
-                    :disabled="disabled"
                     @change="onChangeSystemOpsMode"
                   >
                     {{ values.text }}
@@ -195,7 +193,6 @@
                     v-model="attributeKeys[key]"
                     :value="values.value"
                     :aria-describedby="values.value"
-                    :disabled="disabled"
                   >
                     <template v-if="values.value === 'Power Off'">{{
                       $t('pageServerPowerOperations.biosSettings.powerOff')

--- a/src/views/Operations/ServerPowerOperations/BiosSettings.vue
+++ b/src/views/Operations/ServerPowerOperations/BiosSettings.vue
@@ -26,6 +26,7 @@
               id="bios-option-sysOp-mode"
               v-model="attributeKeys[key]"
               :options="attriValuesArr"
+              :disabled="disabled"
             >
             </b-form-select>
           </b-form-group>
@@ -58,6 +59,7 @@
                     v-model="attributeKeys[key]"
                     :value="values.value"
                     :aria-describedby="values.value"
+                    :disabled="disabled"
                     @change="onChangeSystemOpsMode"
                   >
                     {{ values.text }}

--- a/src/views/Operations/ServerPowerOperations/BiosSettings.vue
+++ b/src/views/Operations/ServerPowerOperations/BiosSettings.vue
@@ -27,6 +27,7 @@
               id="bios-option-sysOp-mode"
               v-model="attributeKeys[key]"
               :options="attriValuesArr"
+              :disabled="disabled"
             >
             </b-form-select>
           </b-form-group>
@@ -59,6 +60,7 @@
                     v-model="attributeKeys[key]"
                     :value="values.value"
                     :aria-describedby="values.value"
+                    :disabled="disabled"
                     @change="onChangeSystemOpsMode"
                   >
                     {{ values.text }}
@@ -194,6 +196,7 @@
                     v-model="attributeKeys[key]"
                     :value="values.value"
                     :aria-describedby="values.value"
+                    :disabled="disabled"
                   >
                     <template v-if="values.value === 'Power Off'">{{
                       $t('pageServerPowerOperations.biosSettings.powerOff')
@@ -273,7 +276,7 @@
               id="bios-option-sysOp-mode"
               v-model="taggedSetting.settingValue"
               :options="taggedSettingsOptions"
-              :disabled="!isAtleastPhypInStandby"
+              :disabled="!isAtleastPhypInStandby || disabled"
               @input="
                 changeTaggedSettingsValue(
                   taggedSetting.settingKey,
@@ -328,7 +331,9 @@
             id="linux_kvm_percentage"
             v-model="linuxKvmPercentageValue"
             type="number"
-            :disabled="attributeKeys.pvm_linux_kvm_memory === 'Automatic'"
+            :disabled="
+              attributeKeys.pvm_linux_kvm_memory === 'Automatic' || disabled
+            "
             step="0.1"
             min="0.0"
             max="100.0"


### PR DESCRIPTION
Description: Disabled the selection till save is success for bios setting
Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=595828

github Issue: https://github.com/ibm-openbmc/openbmc/issues/291



