### PR TITLE
Post changing Hostname, BMC GUI web page need to see updated hostname

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -1129,7 +1129,7 @@
     "dns": "DNS server",
     "domainName": "domain name",
     "hostname": "Hostname",
-    "hostnameAlert": "You will be logged out when the hostname is changed. Changes will take effect on next log in.",
+    "hostnameAlert": "You will be logged out when the hostname is changed. Changes will take effect on next log in. A browser refresh (or closing the browser) might be required",
     "interfaceSection": "Interface settings",
     "ipv4": "IPv4",
     "ipv4Addresses": "IPv4 addresses",

--- a/src/store/modules/Settings/NetworkStore.js
+++ b/src/store/modules/Settings/NetworkStore.js
@@ -546,13 +546,12 @@ const NetworkStore = {
           );
         });
     },
-    async saveHostname({ state, dispatch }, hostname) {
+    async saveHostname({ state }, hostname) {
       return api
         .patch(
           `/redfish/v1/Managers/bmc/EthernetInterfaces/${state.selectedInterfaceId}`,
           hostname
         )
-        .then(dispatch('getEthernetData'))
         .then(() => {
           return i18n.t('pageNetwork.toast.successSaveNetworkSettings', {
             setting: i18n.t('pageNetwork.network'),

--- a/src/views/Settings/Network/Network.vue
+++ b/src/views/Settings/Network/Network.vue
@@ -283,7 +283,7 @@ export default {
       this.startLoader();
       this.$store
         .dispatch('network/saveHostname', modalFormData)
-        .then(this.$store.dispatch('authentication/logout'))
+        .then(() => this.$store.dispatch('authentication/logout'))
         .catch(({ message }) => this.errorToast(message))
         .finally(() => this.endLoader());
     },


### PR DESCRIPTION
Added an additional message for hostname
 - Added an additional warning message for the users regarding the Refresh of the page required after saving the hostname.
 - Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=586748
Signed-off-by: Steffi Antony <“steffiantony196@gmail.com”>
<img width="1719" alt="image" src="https://github.com/ibm-openbmc/webui-vue/assets/125690789/52507839-6b84-4e78-a709-aee322976f20">
