### PR TITLE
Added LocationIndicatorActive check in Inventory page

### DIFF
--- a/src/views/HardwareStatus/Inventory/InventoryTableDimmSlot.vue
+++ b/src/views/HardwareStatus/Inventory/InventoryTableDimmSlot.vue
@@ -69,6 +69,7 @@
       <!-- Toggle identify LED -->
       <template #cell(identifyLed)="row">
         <b-form-checkbox
+          v-if="hasIdentifyLed(row.item.identifyLed)"
           v-model="row.item.identifyLed"
           name="switch"
           switch
@@ -79,6 +80,7 @@
           </span>
           <span v-else> {{ $t('global.status.off') }} </span>
         </b-form-checkbox>
+        <div v-else>--</div>
       </template>
       <template #row-details="{ item }">
         <b-container fluid>
@@ -237,6 +239,9 @@ export default {
         })
         .then((message) => this.successToast(message))
         .catch(({ message }) => this.errorToast(message));
+    },
+    hasIdentifyLed(identifyLed) {
+      return typeof identifyLed === 'boolean';
     },
   },
 };

--- a/src/views/HardwareStatus/Inventory/InventoryTableFans.vue
+++ b/src/views/HardwareStatus/Inventory/InventoryTableFans.vue
@@ -82,6 +82,7 @@
       <!-- Toggle identify LED -->
       <template #cell(identifyLed)="row">
         <b-form-checkbox
+          v-if="hasIdentifyLed(row.item.identifyLed)"
           v-model="row.item.identifyLed"
           name="switch"
           switch
@@ -93,6 +94,7 @@
           </span>
           <span v-else> {{ $t('global.status.off') }} </span>
         </b-form-checkbox>
+        <div v-else>--</div>
       </template>
 
       <template #row-details="{ item }">
@@ -281,6 +283,9 @@ export default {
         })
         .then((message) => this.successToast(message))
         .catch(({ message }) => this.errorToast(message));
+    },
+    hasIdentifyLed(identifyLed) {
+      return typeof identifyLed === 'boolean';
     },
   },
 };

--- a/src/views/HardwareStatus/Inventory/InventoryTablePcieSlots.vue
+++ b/src/views/HardwareStatus/Inventory/InventoryTablePcieSlots.vue
@@ -38,6 +38,7 @@
       <!-- Toggle identify LED -->
       <template #cell(identifyLed)="row">
         <b-form-checkbox
+          v-if="hasIdentifyLed(row.item.identifyLed)"
           v-model="row.item.identifyLed"
           name="switch"
           switch
@@ -49,6 +50,7 @@
           </span>
           <span v-else> {{ $t('global.status.off') }} </span>
         </b-form-checkbox>
+        <div v-else>--</div>
       </template>
 
       <template #row-details="{ item }">
@@ -179,6 +181,9 @@ export default {
         })
         .then((message) => this.successToast(message))
         .catch(({ message }) => this.errorToast(message));
+    },
+    hasIdentifyLed(identifyLed) {
+      return typeof identifyLed === 'boolean';
     },
   },
 };

--- a/src/views/HardwareStatus/Inventory/InventoryTablePowerSupplies.vue
+++ b/src/views/HardwareStatus/Inventory/InventoryTablePowerSupplies.vue
@@ -77,6 +77,7 @@
       <!-- Toggle identify LED -->
       <template #cell(identifyLed)="row">
         <b-form-checkbox
+          v-if="hasIdentifyLed(row.item.identifyLed)"
           v-model="row.item.identifyLed"
           name="switch"
           :disabled="serverStatus"
@@ -88,6 +89,7 @@
           </span>
           <span v-else> {{ $t('global.status.off') }} </span>
         </b-form-checkbox>
+        <div v-else>--</div>
       </template>
       <template #row-details="{ item }">
         <b-container fluid>
@@ -282,6 +284,9 @@ export default {
         })
         .then((message) => this.successToast(message))
         .catch(({ message }) => this.errorToast(message));
+    },
+    hasIdentifyLed(identifyLed) {
+      return typeof identifyLed === 'boolean';
     },
   },
 };


### PR DESCRIPTION
Description: Identify LED On/Off for Power supplies getting failed on BMC GUI page.
Added LocationIndicatorActive check for the power supply Identify LED toggle button
Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=597197
ScreenShots: 
<img width="956" alt="image" src="https://github.com/ibm-openbmc/webui-vue/assets/110152569/23c345fc-2c96-479d-84ca-15bbd84d1046">
<img width="956" alt="image" src="https://github.com/ibm-openbmc/webui-vue/assets/110152569/bc4f108d-4291-4704-9fbf-824cc4e95cf8">

