### PR TITLE
Updated Status in Inventory and LEDs page

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -86,7 +86,8 @@
       "present": "Present",
       "success": "Success",
       "unavailable": "Unavailable",
-      "warning": "Warning"
+      "warning": "Warning",
+      "standbyOffline":"Standby offline"
     },
     "table": {
       "collapseTableRow": "Collapse table row",

--- a/src/views/HardwareStatus/Inventory/InventoryFabricAdapters.vue
+++ b/src/views/HardwareStatus/Inventory/InventoryFabricAdapters.vue
@@ -69,9 +69,15 @@
         {{
           isIoExpansionChassis && isPoweredOff
             ? $t('global.status.unavailable')
+            : row.item.status === 'Present'
+            ? $t('global.status.present')
             : row.item.status === 'Absent'
             ? $t('global.status.absent')
-            : $t('global.status.present')
+            : row.item.status === 'Disabled'
+            ? $t('global.status.disabled')
+            : row.item.status === 'StandbyOffline'
+            ? $t('global.status.standbyOffline')
+            : row.item.status
         }}
       </template>
       <!-- Toggle identify LED -->

--- a/src/views/HardwareStatus/Inventory/InventoryTableAssembly.vue
+++ b/src/views/HardwareStatus/Inventory/InventoryTableAssembly.vue
@@ -73,7 +73,13 @@
             ? $t('global.status.unavailable')
             : row.item.status === 'Present'
             ? $t('global.status.present')
-            : $t('global.status.absent')
+            : row.item.status === 'Absent'
+            ? $t('global.status.absent')
+            : row.item.status === 'Disabled'
+            ? $t('global.status.disabled')
+            : row.item.status === 'StandbyOffline'
+            ? $t('global.status.standbyOffline')
+            : row.item.status
         }}
       </template>
       <!-- Toggle identify LED -->

--- a/src/views/HardwareStatus/Inventory/InventoryTableBmcManager.vue
+++ b/src/views/HardwareStatus/Inventory/InventoryTableBmcManager.vue
@@ -48,7 +48,13 @@
         {{
           row.item.statusState === 'Enabled'
             ? $t('global.status.present')
-            : $t('global.status.absent')
+            : row.item.statusState === 'Absent'
+            ? $t('global.status.absent')
+            : row.item.statusState === 'Disabled'
+            ? $t('global.status.disabled')
+            : row.item.statusState === 'StandbyOffline'
+            ? $t('global.status.standbyOffline')
+            : row.item.statusState
         }}
       </template>
       <!-- Toggle identify LED -->

--- a/src/views/HardwareStatus/Inventory/InventoryTableChassis.vue
+++ b/src/views/HardwareStatus/Inventory/InventoryTableChassis.vue
@@ -39,9 +39,15 @@
       <!-- Status -->
       <template #cell(status)="row">
         {{
-          row.item.statusState === 'Absent'
+          row.item.statusState === 'Enabled'
+            ? $t('global.status.present')
+            : row.item.statusState === 'Absent'
             ? $t('global.status.absent')
-            : $t('global.status.present')
+            : row.item.statusState === 'Disabled'
+            ? $t('global.status.disabled')
+            : row.item.statusState === 'StandbyOffline'
+            ? $t('global.status.standbyOffline')
+            : row.item.statusState
         }}
       </template>
       <!-- Toggle identify LED -->

--- a/src/views/HardwareStatus/Inventory/InventoryTableDimmSlot.vue
+++ b/src/views/HardwareStatus/Inventory/InventoryTableDimmSlot.vue
@@ -63,7 +63,13 @@
         {{
           row.item.status === 'Present'
             ? $t('global.status.present')
-            : $t('global.status.absent')
+            : row.item.status === 'Absent'
+            ? $t('global.status.absent')
+            : row.item.status === 'Disabled'
+            ? $t('global.status.disabled')
+            : row.item.status === 'StandbyOffline'
+            ? $t('global.status.standbyOffline')
+            : row.item.status
         }}
       </template>
       <!-- Toggle identify LED -->

--- a/src/views/HardwareStatus/Inventory/InventoryTableFans.vue
+++ b/src/views/HardwareStatus/Inventory/InventoryTableFans.vue
@@ -75,7 +75,13 @@
             ? $t('global.status.unavailable')
             : row.item.status === 'Present'
             ? $t('global.status.present')
-            : $t('global.status.absent')
+            : row.item.status === 'Absent'
+            ? $t('global.status.absent')
+            : row.item.status === 'Disabled'
+            ? $t('global.status.disabled')
+            : row.item.status === 'StandbyOffline'
+            ? $t('global.status.standbyOffline')
+            : row.item.status
         }}
       </template>
 

--- a/src/views/HardwareStatus/Inventory/InventoryTablePowerSupplies.vue
+++ b/src/views/HardwareStatus/Inventory/InventoryTablePowerSupplies.vue
@@ -71,7 +71,13 @@
             ? $t('global.status.unavailable')
             : row.item.status === 'Present'
             ? $t('global.status.present')
-            : $t('global.status.absent')
+            : row.item.status === 'Absent'
+            ? $t('global.status.absent')
+            : row.item.status === 'Disabled'
+            ? $t('global.status.disabled')
+            : row.item.status === 'StandbyOffline'
+            ? $t('global.status.standbyOffline')
+            : row.item.status
         }}
       </template>
       <!-- Toggle identify LED -->

--- a/src/views/HardwareStatus/Inventory/InventoryTableProcessors.vue
+++ b/src/views/HardwareStatus/Inventory/InventoryTableProcessors.vue
@@ -62,7 +62,13 @@
         {{
           row.item.status === 'Present'
             ? $t('global.status.present')
-            : $t('global.status.absent')
+            : row.item.status === 'Absent'
+            ? $t('global.status.absent')
+            : row.item.status === 'Disabled'
+            ? $t('global.status.disabled')
+            : row.item.status === 'StandbyOffline'
+            ? $t('global.status.standbyOffline')
+            : row.item.status
         }}
       </template>
 

--- a/src/views/HardwareStatus/Inventory/InventoryTableSystem.vue
+++ b/src/views/HardwareStatus/Inventory/InventoryTableSystem.vue
@@ -39,9 +39,15 @@
       <!-- Status -->
       <template #cell(status)="row">
         {{
-          row.item.statusState === 'Absent'
+          row.item.statusState === 'Enabled'
+            ? $t('global.status.present')
+            : row.item.statusState === 'Absent'
             ? $t('global.status.absent')
-            : $t('global.status.present')
+            : row.item.statusState === 'Disabled'
+            ? $t('global.status.disabled')
+            : row.item.statusState === 'StandbyOffline'
+            ? $t('global.status.standbyOffline')
+            : row.item.statusState
         }}
       </template>
 


### PR DESCRIPTION
- After a DDR5 upgrade the BMC GUI inventory displays DIMM information for empty slots (All DIMMs shows up as absent on GUI)
- Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=596355
Signed-off-by: Steffi Antony <“steffiantony196@gmail.com”>