### PR TITLE
Handled DHCP network configurations

### DIFF
--- a/src/views/Settings/Network/Network.vue
+++ b/src/views/Settings/Network/Network.vue
@@ -145,6 +145,7 @@ export default {
       this.prefixLength = item.PrefixLength;
       this.prefixLengthIpv6StaticDefaultGateway = item.PrefixLength;
     });
+    this.$store.dispatch('network/setSelectedTabIndex', 0);
   },
   created() {
     this.startLoader();


### PR DESCRIPTION
- When DHCP is enabled on eth0, eth1 is also getting enabled with DHCP & its network configurations are lost
- Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=598793
Signed-off-by: Steffi Antony <“steffiantony196@gmail.com”>