### PR TITLE
Disabled Power cap fields

### DIFF
--- a/src/views/ResourceManagement/Power/PowerCap.vue
+++ b/src/views/ResourceManagement/Power/PowerCap.vue
@@ -20,7 +20,7 @@
       </b-row>
 
       <b-form @submit.prevent="submitForm">
-        <b-form-group :disabled="loading || safeMode">
+        <b-form-group :disabled="loading || safeMode || powerCapMin === 0">
           <b-row>
             <b-col sm="8" md="6" xl="12">
               <b-form-group :label="$t('pagePower.powerCapSettingLabel')">


### PR DESCRIPTION
-Disabled Power cap fields when it shows garbage value while ongoing code update on BMC GUI. 
-Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=602701
Signed-off-by: Steffi Antony <“steffiantony196@gmail.com”>