### PR TITLE
Added Info tooltip in Inventory and LEDs

### DIFF
--- a/src/views/HardwareStatus/Inventory/InventoryFabricAdapters.vue
+++ b/src/views/HardwareStatus/Inventory/InventoryFabricAdapters.vue
@@ -32,6 +32,10 @@
       :busy="isBusy"
       @filtered="onFiltered"
     >
+      <template #head(identifyLed)="row">
+        {{ row.label }}
+        <info-tooltip :title="$t('pageInventory.identifyLedInfo')" />
+      </template>
       <!-- Expand chevron icon -->
       <template #cell(expandRow)="row">
         <b-button
@@ -146,6 +150,7 @@
 <script>
 import PageSection from '@/components/Global/PageSection';
 import IconChevron from '@carbon/icons-vue/es/chevron--down/20';
+import InfoTooltip from '@/components/Global/InfoTooltip';
 import TableCellCount from '@/components/Global/TableCellCount';
 
 import DataFormatterMixin from '@/components/Mixins/DataFormatterMixin';
@@ -160,7 +165,7 @@ import TableRowExpandMixin, {
 import BVToastMixin from '@/components/Mixins/BVToastMixin';
 
 export default {
-  components: { IconChevron, PageSection, Search, TableCellCount },
+  components: { IconChevron, InfoTooltip, PageSection, Search, TableCellCount },
   mixins: [
     BVToastMixin,
     TableRowExpandMixin,

--- a/src/views/HardwareStatus/Inventory/InventoryTableDimmSlot.vue
+++ b/src/views/HardwareStatus/Inventory/InventoryTableDimmSlot.vue
@@ -31,6 +31,10 @@
       :busy="isBusy"
       @filtered="onFiltered"
     >
+      <template #head(identifyLed)="row">
+        {{ row.label }}
+        <info-tooltip :title="$t('pageInventory.identifyLedInfo')" />
+      </template>
       <!-- Expand chevron icon -->
       <template #cell(expandRow)="row">
         <b-button
@@ -162,6 +166,7 @@ import StatusIcon from '@/components/Global/StatusIcon';
 import TableCellCount from '@/components/Global/TableCellCount';
 import BVToastMixin from '@/components/Mixins/BVToastMixin';
 import DataFormatterMixin from '@/components/Mixins/DataFormatterMixin';
+import InfoTooltip from '@/components/Global/InfoTooltip';
 import TableSortMixin from '@/components/Mixins/TableSortMixin';
 import Search from '@/components/Global/Search';
 import SearchFilterMixin, {
@@ -172,7 +177,14 @@ import TableRowExpandMixin, {
 } from '@/components/Mixins/TableRowExpandMixin';
 
 export default {
-  components: { IconChevron, PageSection, StatusIcon, Search, TableCellCount },
+  components: {
+    IconChevron,
+    InfoTooltip,
+    PageSection,
+    StatusIcon,
+    Search,
+    TableCellCount,
+  },
   mixins: [
     BVToastMixin,
     TableRowExpandMixin,

--- a/src/views/HardwareStatus/Inventory/InventoryTablePcieSlots.vue
+++ b/src/views/HardwareStatus/Inventory/InventoryTablePcieSlots.vue
@@ -35,6 +35,10 @@
       :busy="isBusy"
       @filtered="onFiltered"
     >
+      <template #head(identifyLed)="row">
+        {{ row.label }}
+        <info-tooltip :title="$t('pageInventory.identifyLedInfo')" />
+      </template>
       <!-- Toggle identify LED -->
       <template #cell(identifyLed)="row">
         <b-form-checkbox
@@ -77,6 +81,7 @@ import TableCellCount from '@/components/Global/TableCellCount';
 
 import DataFormatterMixin from '@/components/Mixins/DataFormatterMixin';
 import TableSortMixin from '@/components/Mixins/TableSortMixin';
+import InfoTooltip from '@/components/Global/InfoTooltip';
 import Search from '@/components/Global/Search';
 import SearchFilterMixin, {
   searchFilter,
@@ -84,7 +89,7 @@ import SearchFilterMixin, {
 import BVToastMixin from '@/components/Mixins/BVToastMixin';
 
 export default {
-  components: { PageSection, Search, TableCellCount },
+  components: { PageSection, InfoTooltip, Search, TableCellCount },
   mixins: [BVToastMixin, DataFormatterMixin, TableSortMixin, SearchFilterMixin],
   props: {
     chassis: {

--- a/src/views/HardwareStatus/Inventory/InventoryTablePowerSupplies.vue
+++ b/src/views/HardwareStatus/Inventory/InventoryTablePowerSupplies.vue
@@ -31,6 +31,10 @@
       :busy="isBusy"
       @filtered="onFiltered"
     >
+      <template #head(identifyLed)="row">
+        {{ row.label }}
+        <info-tooltip :title="$t('pageInventory.identifyLedInfo')" />
+      </template>
       <!-- Expand chevron icon -->
       <template #cell(expandRow)="row">
         <b-button
@@ -164,6 +168,7 @@ import IconChevron from '@carbon/icons-vue/es/chevron--down/20';
 import StatusIcon from '@/components/Global/StatusIcon';
 import TableCellCount from '@/components/Global/TableCellCount';
 import DataFormatterMixin from '@/components/Mixins/DataFormatterMixin';
+import InfoTooltip from '@/components/Global/InfoTooltip';
 import TableSortMixin from '@/components/Mixins/TableSortMixin';
 import Search from '@/components/Global/Search';
 import SearchFilterMixin, {
@@ -175,7 +180,14 @@ import TableRowExpandMixin, {
 import BVToastMixin from '@/components/Mixins/BVToastMixin';
 
 export default {
-  components: { IconChevron, PageSection, StatusIcon, Search, TableCellCount },
+  components: {
+    IconChevron,
+    InfoTooltip,
+    PageSection,
+    StatusIcon,
+    Search,
+    TableCellCount,
+  },
   mixins: [
     BVToastMixin,
     TableRowExpandMixin,

--- a/src/views/HardwareStatus/Inventory/InventoryTableProcessors.vue
+++ b/src/views/HardwareStatus/Inventory/InventoryTableProcessors.vue
@@ -31,6 +31,10 @@
       :busy="isBusy"
       @filtered="onFiltered"
     >
+      <template #head(identifyLed)="row">
+        {{ row.label }}
+        <info-tooltip :title="$t('pageInventory.identifyLedInfo')" />
+      </template>
       <!-- Expand button -->
       <template #cell(expandRow)="row">
         <b-button
@@ -156,6 +160,7 @@ import IconChevron from '@carbon/icons-vue/es/chevron--down/20';
 import StatusIcon from '@/components/Global/StatusIcon';
 import TableCellCount from '@/components/Global/TableCellCount';
 import BVToastMixin from '@/components/Mixins/BVToastMixin';
+import InfoTooltip from '@/components/Global/InfoTooltip';
 import TableSortMixin from '@/components/Mixins/TableSortMixin';
 import DataFormatterMixin from '@/components/Mixins/DataFormatterMixin';
 import Search from '@/components/Global/Search';
@@ -167,7 +172,14 @@ import TableRowExpandMixin, {
 } from '@/components/Mixins/TableRowExpandMixin';
 
 export default {
-  components: { IconChevron, PageSection, StatusIcon, Search, TableCellCount },
+  components: {
+    IconChevron,
+    InfoTooltip,
+    PageSection,
+    StatusIcon,
+    Search,
+    TableCellCount,
+  },
   mixins: [
     BVToastMixin,
     TableRowExpandMixin,


### PR DESCRIPTION
- In Bonnell, we might not have some LEDs present. So, as an info, we have added a note to all the tables that has LEDs: "For parts with no LEDs, the Identify LED toggle switch will only turn on the Enclosure LED"
- Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=600508

![image](https://github.com/ibm-openbmc/webui-vue/assets/96164786/d491c1e6-9d2c-42e3-81ce-e6322feaf675)
