### PR TITLE
Updated toast message when IBM i options are saved

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -1767,7 +1767,8 @@
       "errorSaveSettings": "Error saving settings.",
       "successSaveSettings": "Successfully saved settings.",
       "successSaveLinuxKvmSettings": "Successfully saved settings. Changes made will take effect on next reboot.",
-      "successSaveIBMiStandby": "Please press the `Continue to OS running` link to proceed."
+      "successSaveIBMiStandby": "If changes made in IBM i load source, IBM i alternate restart device, or IBM i console, please press the `Continue to OS running` link to proceed.",
+      "successSaveIbmiOsRunningInfo": "Changes made in either IBM i load source, IBM i alternate restart device, or IBM i console will be applied from the next OS boot onwards."
     }
   },
   "pageServiceLoginConsoles": {

--- a/src/views/Operations/ServerPowerOperations/BootSettings.vue
+++ b/src/views/Operations/ServerPowerOperations/BootSettings.vue
@@ -110,21 +110,33 @@ export default {
                 )
               );
             } else if (
-              settings.biosSettings.pvm_default_os_type == 'IBM I' &&
-              this.isAtleastPhypInStandby
+              (settings.biosSettings.pvm_default_os_type == 'IBM I' &&
+                this.isAtleastPhypInStandby) ||
+              (settings.biosSettings.pvm_default_os_type == 'Default' &&
+                this.isAtleastPhypInStandby)
             ) {
               if (this.isInPhypStandby) {
-                this.successToast(
+                this.infoToast(
                   this.$t(
                     'pageServerPowerOperations.toast.successSaveIBMiStandby'
                   )
-                );
+                ),
+                  this.successToast(
+                    this.$t(
+                      'pageServerPowerOperations.toast.successSaveSettings'
+                    )
+                  );
               } else {
-                this.successToast(
+                this.infoToast(
                   this.$t(
-                    'pageServerPowerOperations.toast.successSaveLinuxKvmSettings'
+                    'pageServerPowerOperations.toast.successSaveIbmiOsRunningInfo'
                   )
-                );
+                ),
+                  this.successToast(
+                    this.$t(
+                      'pageServerPowerOperations.toast.successSaveSettings'
+                    )
+                  );
               }
             } else {
               this.successToast(message);


### PR DESCRIPTION
- Updated the toast message when IBM i options are changed and saved in two situations:
	- When the system is in PHYP standby mode
	- Changes made after the user clicks on 'continue to os running' / when system is on (not in phyp standby)

- Changes made as per a comment mentioned in defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=601057