### PR TITLE
Added info message on Dumps page.

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -627,7 +627,8 @@
       "successStartBmcDumpTitle": "BMC dump started",
       "successStartDump": "The dump will take some time to complete.",
       "successStartResourceDumpTitle": "Resource dump started",
-      "successStartSystemDumpTitle": "System dump started"
+      "successStartSystemDumpTitle": "System dump started",
+      "successSavePartitionDumpInfo": "Partition and Retry partition dump will be listed as Resource Dump Entry"
     }
   },
   "pageEventLogs": {

--- a/src/views/Logs/Dumps/DumpsForm.vue
+++ b/src/views/Logs/Dumps/DumpsForm.vue
@@ -269,7 +269,12 @@ export default {
     exceuteFunction(value) {
       this.$store
         .dispatch('ibmiServiceFunctions/executeServiceFunction', value)
-        .then((message) => this.successToast(message))
+        .then((message) => {
+          this.infoToast(
+            this.$t('pageDumps.toast.successSavePartitionDumpInfo')
+          );
+          this.successToast(message);
+        })
         .catch(({ message }) => this.errorToast(message));
     },
     isFunctionDisabled(value) {


### PR DESCRIPTION
- Informational message displayed on the dumps page if Partition and Retry partition dump has been initiated. 
- Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=600242
Signed-off-by: Steffi Antony <“steffiantony196@gmail.com”>
![Screenshot 2024-03-27 at 12-54-17 a902be-sioi-bonnell1 - Dumps](https://github.com/ibm-openbmc/webui-vue/assets/125690789/2d38160f-0aab-4f77-9c43-f7d8e247c2f2)

