### PR TITLE
ReadOnly user - Inconsistent unauthorised message fix

### DIFF
--- a/src/components/AppHeader/AppHeader.vue
+++ b/src/components/AppHeader/AppHeader.vue
@@ -105,7 +105,7 @@
         </b-navbar-nav>
       </b-navbar>
     </header>
-    <loading-bar @checkLoadingStatus="checkLoadingStatus" />
+    <loading-bar />
   </div>
 </template>
 
@@ -137,7 +137,6 @@ export default {
   },
   data() {
     return {
-      loadingStatus: null,
       isNavigationOpen: false,
       altLogo: process.env.VUE_APP_COMPANY_NAME || 'Built on OpenBMC',
       headerText: 'ASMI',
@@ -196,7 +195,7 @@ export default {
   },
   watch: {
     isAuthorized(value) {
-      if (value === false && this.loadingStatus) {
+      if (value === false) {
         this.errorToast(this.$t('global.toast.unAuthDescription'), {
           title: this.$t('global.toast.unAuthTitle'),
         });
@@ -217,9 +216,6 @@ export default {
     );
   },
   methods: {
-    checkLoadingStatus(loadingStatus) {
-      this.loadingStatus = loadingStatus;
-    },
     getSystemInfo() {
       this.$store.dispatch('global/getSystemInfo');
     },

--- a/src/store/api.js
+++ b/src/store/api.js
@@ -34,9 +34,10 @@ api.interceptors.response.use(undefined, (error) => {
     // when the action is unauthorized.
     // Hardware deconfiguration is an exception to this
     const url = response.config.url;
+    const notGetMethod = response.config.method !== 'get';
     const coreUrl = 'redfish/v1/Systems/system/Processors';
     const memoryUrl = 'redfish/v1/Systems/system/Memory';
-    if (!(url.includes(coreUrl) || url.includes(memoryUrl)))
+    if (!(url.includes(coreUrl) || url.includes(memoryUrl)) && notGetMethod)
       store.commit('global/setUnauthorized');
   }
 


### PR DESCRIPTION
- Fixed unauthorised message not prompted when a read-only user triggers certain actions.

- Unauthorised message was not displayed when the app receives a 403 response when the loading animation was still going on. Fixed the issue in this commit.

- Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=600168

Before:
![Screen shot 1](https://github.com/ibm-openbmc/webui-vue/assets/29519067/0e4fd9ce-d4a9-4169-92af-e83a9610e7e9)

After:
![Screenshot 2024-03-28 at 10 45 24 AM](https://github.com/ibm-openbmc/webui-vue/assets/29519067/e63ac587-b064-4d75-9e41-7ae360f763f5)

