### PR TITLE
Updated Location codes check

### DIFF
--- a/src/store/modules/Operations/BootSettingsStore.js
+++ b/src/store/modules/Operations/BootSettingsStore.js
@@ -233,9 +233,15 @@ const BootSettingsStore = {
         .then(({ data }) => {
           data.Members.map((chassis) => {
             chassis.PCIeSlots.Slots.map((pcieSlot) => {
-              locationCodes.push(
+              if (
+                pcieSlot?.Links?.PCIeDevice &&
+                pcieSlot?.Links?.PCIeDevice.length > 0 &&
                 pcieSlot?.Location?.PartLocation?.ServiceLabel
-              );
+              ) {
+                locationCodes.push(
+                  pcieSlot?.Location?.PartLocation?.ServiceLabel
+                );
+              }
             });
           });
           commit('setLocationCodes', locationCodes);


### PR DESCRIPTION
- We were getting and displaying all the location codes listed in the PCIe slots for IBM i load source, IBM i alternate restart device and IBM i console. Now, we are only listing the Location codes of the slots which are connected PCIe device.
- Defect: https://jazz07.rchland.ibm.com:13443/jazz/resource/itemName/com.ibm.team.workitem.WorkItem/603682