### PR TITLE
Added IBM i/Default check in dumps

### DIFF
--- a/src/views/Logs/Dumps/DumpsForm.vue
+++ b/src/views/Logs/Dumps/DumpsForm.vue
@@ -252,7 +252,7 @@ export default {
       this.dumpTypeOptions = [];
       if (this.hmcInfo === 'Enabled') {
         return (this.dumpTypeOptions = minimumOptions);
-      } else {
+      } else if (this.isIBMi) {
         return (this.dumpTypeOptions = [
           ...minimumOptions,
           {
@@ -264,6 +264,8 @@ export default {
             text: this.$t('pageDumps.form.retryPartitionDump'),
           },
         ]);
+      } else {
+        return (this.dumpTypeOptions = minimumOptions);
       }
     },
     exceuteFunction(value) {


### PR DESCRIPTION
- We will show the partition dumps or retry partition dumps options in the dumps page only when the Default partition environment is IBM i or Default, Else we will hide them.