### PR TITLE
Support for Concurrent maintenance in IPS Everest

### DIFF
--- a/src/env/components/AppNavigation/ibm.js
+++ b/src/env/components/AppNavigation/ibm.js
@@ -277,7 +277,10 @@ const AppNavigationMixin = {
       return this.$store?.getters?.['global/currentUser']?.RoleId;
     },
     model() {
-      if (this.systemInfo?.startsWith('9043')) {
+      if (
+        this.systemInfo?.startsWith('9043') ||
+        this.systemInfo?.startsWith('8860')
+      ) {
         return 'Everest';
       } else {
         return 'NotEverest';


### PR DESCRIPTION
Modified the condition check for displaying the IPS equivalent Everest model along with Everest Concurrent Maintenance page, if it is an Everest model. 
Jira: https://jsw.ibm.com/browse/PFEBMC-2685
Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=614706
Signed-off-by: Steffi Antony <“steffiantony196@gmail.com”>