### PR TITLE
Informational message displayed to the user only when some power oper…

### DIFF
--- a/src/views/Operations/ServerPowerOperations/ServerPowerOperations.vue
+++ b/src/views/Operations/ServerPowerOperations/ServerPowerOperations.vue
@@ -372,15 +372,23 @@ export default {
           this.$bvModal
             .msgBoxConfirm(modalMessage, modalOptions)
             .then((confirmed) => {
-              if (confirmed) this.$store.dispatch('controls/serverSoftReboot');
-              this.infoToast(this.$t('pageServerPowerOperations.userRefresh'));
+              if (confirmed) {
+                this.$store.dispatch('controls/serverSoftReboot');
+                this.infoToast(
+                  this.$t('pageServerPowerOperations.userRefresh')
+                );
+              }
             });
         } else if (this.form.rebootOption === 'immediate') {
           this.$bvModal
             .msgBoxConfirm(modalMessage, modalOptions)
             .then((confirmed) => {
-              if (confirmed) this.$store.dispatch('controls/serverHardReboot');
-              this.infoToast(this.$t('pageServerPowerOperations.userRefresh'));
+              if (confirmed) {
+                this.$store.dispatch('controls/serverHardReboot');
+                this.infoToast(
+                  this.$t('pageServerPowerOperations.userRefresh')
+                );
+              }
             });
         }
       });
@@ -404,16 +412,20 @@ export default {
         this.$bvModal
           .msgBoxConfirm(modalMessage, modalOptions)
           .then((confirmed) => {
-            if (confirmed) this.$store.dispatch('controls/serverSoftPowerOff');
-            this.infoToast(this.$t('pageServerPowerOperations.userRefresh'));
+            if (confirmed) {
+              this.$store.dispatch('controls/serverSoftPowerOff');
+              this.infoToast(this.$t('pageServerPowerOperations.userRefresh'));
+            }
           });
       }
       if (this.form.shutdownOption === 'immediate') {
         this.$bvModal
           .msgBoxConfirm(modalMessage, modalOptions)
           .then((confirmed) => {
-            if (confirmed) this.$store.dispatch('controls/serverHardPowerOff');
-            this.infoToast(this.$t('pageServerPowerOperations.userRefresh'));
+            if (confirmed) {
+              this.$store.dispatch('controls/serverHardPowerOff');
+              this.infoToast(this.$t('pageServerPowerOperations.userRefresh'));
+            }
           });
       }
     },


### PR DESCRIPTION
Informational message displayed to the user only when some power operation is confirmed by the user

- Informational message displayed to the user only when some power operation is confirmed by the user
- Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=613776