### PR TITLE
Update ID to Name for Processors

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -489,6 +489,7 @@
       "id": "Id",
       "locationCode": "Location Code",
       "name": "Name",
+      "processorName": "Processor Name",
       "pelId": "Pel ID",
       "eventId": "Event ID",
       "settings": "Settings",

--- a/src/store/modules/Settings/HardwareDeconfigurationStore.js
+++ b/src/store/modules/Settings/HardwareDeconfigurationStore.js
@@ -41,9 +41,9 @@ const HardwareDeconfigurationStore = {
         .get(`${id}`)
         .then((response) => response.data.Location.PartLocation.ServiceLabel)
         .catch((error) => console.log(error));
-      const procId = await api
+      const procData = await api
         .get(`${id}`)
-        .then((response) => response.data.Id)
+        .then((response) => response.data)
         .catch((error) => console.log(error));
       const cores = await api
         .get(`${id}/SubProcessors`)
@@ -110,7 +110,8 @@ const HardwareDeconfigurationStore = {
                   : msgArgs === 'Unknown'
                   ? i18n.t('pageDeconfigurationHardware.table.filter.unknown')
                   : msgArgs,
-              processorId: procId,
+              processorId: procData.Id,
+              processorName: procData.Name,
               eventID: eventId,
             };
           });

--- a/src/views/HardwareStatus/Inventory/InventoryTableProcessors.vue
+++ b/src/views/HardwareStatus/Inventory/InventoryTableProcessors.vue
@@ -48,6 +48,14 @@
           <span class="sr-only">{{ expandRowLabel }}</span>
         </b-button>
       </template>
+      <!-- Name -->
+      <template #cell(name)="{ value }">
+        {{
+          value === 'Processor Module'
+            ? $t('pageInventory.processorModule')
+            : dataFormatter(value)
+        }}
+      </template>
       <!-- Health -->
       <template #cell(health)="{ value }">
         <status-icon :status="statusIcon(value)" />
@@ -115,14 +123,10 @@
           <b-row>
             <b-col class="mt-2" sm="6" xl="6">
               <dl>
-                <!-- Name -->
-                <dt>{{ $t('pageInventory.table.name') }}</dt>
+                <!-- Id -->
+                <dt>{{ $t('pageInventory.table.id') }}</dt>
                 <dd>
-                  {{
-                    item.name === 'Processor Module'
-                      ? $t('pageInventory.processorModule')
-                      : dataFormatter(item.name)
-                  }}
+                  {{ dataFormatter(item.id) }}
                 </dd>
                 <!-- Part Number -->
                 <dt>{{ $t('pageInventory.table.partNumber') }}</dt>
@@ -199,7 +203,7 @@ export default {
           sortable: false,
         },
         {
-          key: 'id',
+          key: 'name',
           label: this.$t('pageInventory.table.name'),
           formatter: this.dataFormatter,
           sortable: true,

--- a/src/views/Settings/HardwareDeconfiguration/ProcessorCores.vue
+++ b/src/views/Settings/HardwareDeconfiguration/ProcessorCores.vue
@@ -144,6 +144,11 @@ export default {
       isBusy: true,
       fields: [
         {
+          key: 'processorName',
+          sortable: true,
+          label: this.$t('pageDeconfigurationHardware.table.processorName'),
+        },
+        {
           key: 'processorId',
           sortable: true,
           label: this.$t('pageDeconfigurationHardware.table.id'),


### PR DESCRIPTION
- In the Inventory and LEDs page and Hardware Deconfiguration page, ID is changed to Name.
- Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=602233