### PR TITLE
Displaying empty for progress code '00000000'

### DIFF
--- a/src/views/Logs/PostCodeLogs/PostCodes.vue
+++ b/src/views/Logs/PostCodeLogs/PostCodes.vue
@@ -26,11 +26,13 @@ export default {
           let finalConvertedCode = bytearray.toString();
           // Filter out all non readable values and all 00000000
           // Yes, whitespaces for 'STANDBY ' and 'RUNTIME ' must be there
-          if (
+          if (finalConvertedCode === '00000000') {
+            this.setPreviousPostCode('');
+            return '';
+          } else if (
             finalConvertedCode === 'STANDBY ' ||
             finalConvertedCode === 'RUNTIME ' ||
-            (finalConvertedCode != '00000000' &&
-              /^[a-z0-9 ]+$/i.test(finalConvertedCode))
+            /^[a-z0-9 ]+$/i.test(finalConvertedCode)
           ) {
             this.setPreviousPostCode(finalConvertedCode);
             return finalConvertedCode;


### PR DESCRIPTION
- When we encounter '00000000', we were displaying the previous valid progress code. Now, in this change, we will be displaying '' instead.

- Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=612044