### PR TITLE
1060: Fixed Arrow icon

### DIFF
--- a/src/views/Operations/ServerPowerOperations/BiosSettings.vue
+++ b/src/views/Operations/ServerPowerOperations/BiosSettings.vue
@@ -953,9 +953,15 @@ export default {
   },
 };
 </script>
-<style lang="scss">
+
+<style lang="scss" scoped>
 .error-text {
   color: red;
   font-size: 12px;
+}
+.btn.collapsed {
+  svg {
+    transform: rotate(180deg);
+  }
 }
 </style>

--- a/src/views/ResourceManagement/Power/PowerPerformanceModes.vue
+++ b/src/views/ResourceManagement/Power/PowerPerformanceModes.vue
@@ -131,3 +131,11 @@ export default {
   },
 };
 </script>
+
+<style lang="scss" scoped>
+.btn.collapsed {
+  svg {
+    transform: rotate(180deg);
+  }
+}
+</style>


### PR DESCRIPTION
- Arrow icon was not updating in the collapse, always showed Arrow up. Fixed this issue to show both Arrow-up and Arrow-down.

- Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=625401

- Equivalent PR: https://github.com/ibm-openbmc/webui-vue/pull/250