### PR TITLE
Monitoring tasks while generating resource dump

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -624,6 +624,8 @@
       "errorStartResourceDumpInvalidSelector": "Error initiating dump. Invalid resource selector.",
       "errorStartResourceDumpInvalidPassword": "Error initiating dump. Invalid password.",
       "errorStartSystemDump": "Error starting new System dump.",
+      "resourceDumpSuccess": "Resource Dump created successfully.",
+      "resourceDumpFailed": "Resource Dump creation failed.",
       "successDeleteDump": "Successfully deleted %{count} dump. | Successfully deleted %{count} dumps.",
       "successStartBmcDumpTitle": "BMC dump started",
       "successStartDump": "The dump will take some time to complete.",

--- a/src/store/modules/Logs/DumpsStore.js
+++ b/src/store/modules/Logs/DumpsStore.js
@@ -23,6 +23,9 @@ const DumpsStore = {
     },
   },
   actions: {
+    async getTask() {
+      return await api.get('/redfish/v1/TaskService/Tasks');
+    },
     async getBmcDumpEntries() {
       return api
         .get('/redfish/v1/')


### PR DESCRIPTION
- Monitoring the task while generating the resource dump to alert the user of any failures during the process.
- Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=383586