### PR TITLE
Updated LanesInUse default value

### DIFF
--- a/src/store/modules/HardwareStatus/PcieTopologyStore.js
+++ b/src/store/modules/HardwareStatus/PcieTopologyStore.js
@@ -758,7 +758,7 @@ const PcieTopologyStore = {
             if (slot?.pcieDevice) {
               row.linkSpeed = slot?.pcieDevice?.PCIeInterface?.PCIeType;
               row.linkWidth =
-                slot?.pcieDevice?.PCIeInterface?.LanesInUse === -1
+                slot?.pcieDevice?.PCIeInterface?.LanesInUse === null
                   ? 'unknown'
                   : slot?.pcieDevice?.PCIeInterface?.LanesInUse;
               if (


### PR DESCRIPTION
- LanesInUse default value is changed to null.
- JIRA: https://jsw.ibm.com/browse/PFEBMC-3025
- bmcweb change: https://github.com/ibm-openbmc/bmcweb/pull/851
- Slack discussion: https://ibm-systems-power.slack.com/archives/C0Q6TQP5Z/p1718139726901369