### PR TITLE
Power page modal fix

### DIFF
--- a/src/views/ResourceManagement/Power/ModalPowerPerformanceModes.vue
+++ b/src/views/ResourceManagement/Power/ModalPowerPerformanceModes.vue
@@ -1,7 +1,7 @@
 <template>
   <BModal
     id="modal-power-performance-modes"
-    ref="modal"
+    v-model="modal"
     :title="$t(`pagePower.modalEnablePowerPerformanceMode.title${title}`)"
     :ok-title="$t(`pagePower.modalEnablePowerPerformanceMode.title${title}`)"
   >
@@ -28,6 +28,6 @@ defineProps({
 const modal = ref(null);
 
 eventBus.on('modal-power-performance-modes', () => {
-  modal.value.show();
+  modal.value = true;
 });
 </script>


### PR DESCRIPTION
  - Fixed modal.value being null on rare cases when composition API runs before template is being rendered.

  - Removed template ref and added v-model instead.