### PR TITLE
Removed grey out option in Policies page

### DIFF
--- a/src/views/SecurityAndAccess/Policies/Policies.vue
+++ b/src/views/SecurityAndAccess/Policies/Policies.vue
@@ -146,7 +146,6 @@
             <b-form-checkbox
               id="usbFirmwareUpdatePolicySwitch"
               v-model="usbFirmwareUpdatePolicyState"
-              :disabled="!(isAdminUser || isServiceUser)"
               data-test-id="policies-toggle-usbFirmwareUpdatePolicy"
               switch
               @change="changeUsbFirmwareUpdatePolicyState"


### PR DESCRIPTION
- Removed grey out option for USB firmware update policy in Policies page for read-only users.
- Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=653718