### PR TITLE
Removed grey out option in Policies page

### DIFF
--- a/src/views/SecurityAndAccess/Policies/Policies.vue
+++ b/src/views/SecurityAndAccess/Policies/Policies.vue
@@ -148,7 +148,6 @@
               id="usbFirmwareUpdatePolicySwitch"
               v-model="Policies.usbFirmwareUpdatePolicyEnabled"
               data-test-id="policies-toggle-usbFirmwareUpdatePolicy"
-              :disabled="!(username === 'admin' || username === 'service')"
               switch
               @update:modelValue="changeUsbFirmwareUpdatePolicyState"
             >


### PR DESCRIPTION
- Removed grey out option for USB firmware update policy in Policies page for read-only users.
- Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=653718