### PR TITLE
Fixed “View all” issue in pagination

### DIFF
--- a/src/components/Composables/usePaginationComposable.js
+++ b/src/components/Composables/usePaginationComposable.js
@@ -24,8 +24,8 @@ export const itemsPerPageOptions = [
   },
 ];
 const usePaginationComposable = () => {
-  const getTotalRowCount = (count) => {
-    return perPage === 0 ? 0 : count;
+  const getTotalRowCount = (count, itemPerPage) => {
+    return itemPerPage === 0 ? 1 : count;
   };
 
   return {

--- a/src/views/HardwareStatus/Sensors/Sensors.vue
+++ b/src/views/HardwareStatus/Sensors/Sensors.vue
@@ -112,7 +112,7 @@
           first-number
           last-number
           :per-page="itemPerPage"
-          :total-rows="getTotalRowCount(filteredRows)"
+          :total-rows="getTotalRowCount(filteredRows, itemPerPage)"
           aria-controls="table-sensors"
         />
       </BCol>

--- a/src/views/Logs/AuditLogs/AuditLogs.vue
+++ b/src/views/Logs/AuditLogs/AuditLogs.vue
@@ -124,7 +124,7 @@
           first-number
           last-number
           :per-page="itemPerPage"
-          :total-rows="getTotalRowCount(filteredRows)"
+          :total-rows="getTotalRowCount(filteredRows, itemPerPage)"
           aria-controls="table-audit-logs"
         />
       </BCol>

--- a/src/views/SecurityAndAccess/Sessions/Sessions.vue
+++ b/src/views/SecurityAndAccess/Sessions/Sessions.vue
@@ -126,7 +126,7 @@
           first-number
           last-number
           :per-page="itemPerPage"
-          :total-rows="getTotalRowCount(filteredRows)"
+          :total-rows="getTotalRowCount(filteredRows, itemPerPage)"
           aria-controls="table-session-logs"
         />
       </BCol>


### PR DESCRIPTION
- When clicked on “View all”, Only one page must be displayed but the number of pages is more than 1. Fixed in this change.
- Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=654693