### PR TITLE
1MD: Spare Cores: Deconfiguration Records

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -518,7 +518,7 @@
       "confirmMessage": "Clearing all deconfiguration records will attempt to reconfigure all hardware in the selected node(s). These changes will take effect on the next boot.",
       "deleteAllMessage": "Are you sure you want to delete all records? This action cannot be undone.",
       "deleteAllTitle": "Delete all records",
-      "deleteMessage": "Are you sure you want to delete %{count} records? This action cannot be undone. | Are you sure you want to delete %{count} records? This action cannot be undone.",
+      "deleteMessage": "Are you sure you want to delete %{count} record? This action cannot be undone. | Are you sure you want to delete %{count} records? This action cannot be undone.",
       "deleteTitle": "Delete record | Delete records",
       "goBack": "Go back",
       "continue": "Continue"
@@ -542,7 +542,8 @@
     "severityValues": {
       "fatal": "Fatal",
       "predictive": "Predictive",
-      "manual": "Manual"
+      "manual": "Manual",
+      "spare": "Spare"
     },
     "toast": {
       "errorDelete": "Error deleting %{count} record. | Error deleting %{count} records.",

--- a/src/store/modules/Logs/DeconfigurationRecordsStore.js
+++ b/src/store/modules/Logs/DeconfigurationRecordsStore.js
@@ -49,9 +49,8 @@ const DeconfigurationRecordsStore = {
             allMembers.map(async (log) => {
               const {
                 Id,
-                Severity,
+                MessageArgs,
                 Created,
-                Message,
                 Name,
                 AdditionalDataURI,
                 AdditionalData = AdditionalDataURI
@@ -70,7 +69,7 @@ const DeconfigurationRecordsStore = {
               return {
                 additionalDataUri: AdditionalDataURI,
                 date: new Date(Created),
-                description: Message,
+                description: MessageArgs[1],
                 filterByStatus: AdditionalData?.Resolved
                   ? 'Resolved'
                   : 'Unresolved',
@@ -80,7 +79,7 @@ const DeconfigurationRecordsStore = {
                 srcDetails: AdditionalData?.EventId,
                 status: AdditionalData?.Resolved, //true or false
                 uri: log['@odata.id'],
-                severity: Severity,
+                severity: MessageArgs[0],
                 location: LocationCode,
                 eventID: eventId,
               };
@@ -147,6 +146,21 @@ const DeconfigurationRecordsStore = {
           console.log(error);
           throw new Error(
             i18n.t('pageDeconfigurationRecords.toast.errorStartDownload')
+          );
+        });
+    },
+    async deleteRecords({ dispatch }, uris = []) {
+      const promises = uris.map((uri) => api.delete(uri));
+      return await api
+        .all(promises)
+        .then(() => dispatch('getDeconfigurationRecordInfo'))
+        .then(() =>
+          i18n.tc('pageDeconfigurationRecords.toast.successDelete', uris.length)
+        )
+        .catch((error) => {
+          console.log(error);
+          throw new Error(
+            i18n.tc('pageDeconfigurationRecords.toast.errorDelete', uris.length)
           );
         });
     },


### PR DESCRIPTION
- Updated the description of 'Severity' and 'Resource' column
- Added delete option for individual record
- Story: https://jsw.ibm.com/browse/PFEBMC-2884