### PR TITLE
Support for new power modes

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -1434,6 +1434,10 @@
       "message3": "The system will attempt to exit Safe Mode on the next power on attempt. To reboot the server, visit",
       "message3Link": "server power operations"
     },
+    "oemMode": {
+      "message1": "System is currently in Custom mode.",
+      "message2": "Change mode by selecting on the appropriate option."
+    },
     "delayTimeValidation": {
       "delayTimeRange": "Value must be between %{min} and %{max}.",
       "enterDelayTime": "Value cannot be less than delay time to exit.",
@@ -1444,18 +1448,27 @@
       "content": "Enabling any of the power saver modes will cause changes in processor frequencies, changes in processor utilization, changes in power consumption, and performance to vary.",
       "subTitle": "Are you sure?",
       "titleMaximumPerformance": "Enable maximum performance mode",
-      "titlePowerSaving": "Enable power saving mode",
-      "titleStatic": "Enable static mode"
+      "titleEfficiencyFavorPower": "Enable energy efficient mode",
+      "titlePowerSaving": "Enable maximum energy saver mode"
     },
     "selectMode": {
-      "maximumPerformance": "Maximum performance",
-      "powerSaving": "Power saving",
-      "static": "Static"
+      "maximumPerformance": {
+        "primary": "Maximum performance",
+        "secondary": "Maximum performance"
+      },
+      "energyEfficient": {
+        "primary": "Energy efficient",
+        "secondary": "Efficiency favor power"
+      },
+      "maximumEnergySaver": {
+        "primary": "Maximum energy saver",
+        "secondary": "Power saver"
+      }
     },
     "tableRoles": {
-      "descMaximumPerformance": "Processor frequency will vary. This mode allows the system to reach the maximum frequency by taking advantage of the thermal and power headroom provided by idle cores, lower workloads, and favorable environmental conditions.",
-      "descPowerSaving": "Processor frequency is set to a fixed minimum value, reducing the power consumption of the system while still delivering predictable performance.",
-      "descStatic": "Processor frequency is set to a fixed value that can run normal workloads under normal environmental conditions.",
+      "descMaximumPerformance": "Processor frequency will vary. This mode allows systems to reach the maximum-frequency value by taking advantage of thermal and energy headroom provided by idle cores, lower workloads, and favorable environmental conditions.",
+      "descEnergyEfficient": "Processor frequency will vary. This mode allows systems to reach mid-frequency values by taking advantage of thermal and energy headroom provided by idle cores, lower workloads, and favorable environmental conditions.",
+      "descMaximumEnergySaver": "Processors are set to a fixed low-frequency value regardless of workload and environment temperatures, reducing energy consumption while still delivering predictable performance.",
       "description": "Description",
       "setting": "Setting"
     },

--- a/src/store/modules/ResourceManagement/PowerControlStore.js
+++ b/src/store/modules/ResourceManagement/PowerControlStore.js
@@ -23,6 +23,7 @@ const PowerControlStore = {
     powerPerformanceMode: (state) => state.powerPerformanceMode,
     powerPerformanceModeValues: (state) => state.powerPerformanceModeValues,
     idlePowerSaverData: (state) => state.idlePowerSaverData,
+    oemMode: (state) => state.powerPerformanceMode === 'OEM',
   },
   mutations: {
     setPowerConsumption: (state, powerConsumptionValue) =>

--- a/src/views/ResourceManagement/Power/Power.vue
+++ b/src/views/ResourceManagement/Power/Power.vue
@@ -27,7 +27,11 @@
     </b-row>
     <power-cap :safe-mode="safeMode" />
     <power-performance-modes :safe-mode="safeMode" />
-    <power-idle-saver :safe-mode="safeMode" />
+    <power-idle-saver
+      :oem-mode="oemMode"
+      :safe-mode="safeMode"
+      :non-idle-power-saver-mode="nonIdlePowerSaverMode"
+    />
   </b-container>
 </template>
 
@@ -61,6 +65,17 @@ export default {
   computed: {
     safeMode() {
       return this.$store.getters['global/safeMode'];
+    },
+    oemMode() {
+      return this.$store.getters['powerControl/oemMode'];
+    },
+    nonIdlePowerSaverMode() {
+      return (
+        this.$store.getters['powerControl/powerPerformanceMode'] ===
+          'EfficiencyFavorPower' ||
+        this.$store.getters['powerControl/powerPerformanceMode'] ===
+          'PowerSaving'
+      );
     },
   },
   created() {

--- a/src/views/ResourceManagement/Power/PowerIdleSaver.vue
+++ b/src/views/ResourceManagement/Power/PowerIdleSaver.vue
@@ -6,7 +6,7 @@
           <b-form-group>
             <b-form-checkbox
               v-model="idlePowerSaver.isIdlePowerSaverEnabled"
-              :disabled="loading || safeMode"
+              :disabled="isDisabled"
               data-test-id="power-checkbox-toggleIdlePower"
               name="idle-power-saver"
             >
@@ -22,7 +22,7 @@
         @submit.prevent="saveIdlePowerSaverData"
         @reset.prevent="resetIdlePowerSaverData"
       >
-        <b-form-group :disabled="loading || safeMode">
+        <b-form-group :disabled="isDisabled">
           <div class="font-weight-bold mb-2">{{ $t('pagePower.toEnter') }}</div>
           <b-row>
             <b-col sm="8" md="6" xl="4">
@@ -196,6 +196,14 @@ export default {
       type: Boolean,
       default: null,
     },
+    oemMode: {
+      type: Boolean,
+      default: null,
+    },
+    nonIdlePowerSaverMode: {
+      type: Boolean,
+      default: null,
+    },
   },
   data() {
     return {
@@ -217,11 +225,27 @@ export default {
     idlePowerSaverData() {
       return this.$store.getters['powerControl/idlePowerSaverData'];
     },
+    isDisabled() {
+      return (
+        this.loading ||
+        this.safeMode ||
+        this.oemMode ||
+        this.nonIdlePowerSaverMode
+      );
+    },
+  },
+  watch: {
+    idlePowerSaverData: function (newValue) {
+      if (this.nonIdlePowerSaverMode || this.safeMode || this.oemMode) {
+        this.setIdlePowerSaveFormValues(null);
+      } else {
+        this.setIdlePowerSaveFormValues(newValue);
+      }
+    },
   },
   created() {
     this.startLoader();
     this.$store.dispatch('powerControl/getIdlePowerSaverData').finally(() => {
-      this.setIdlePowerSaveFormValues(this.idlePowerSaverData);
       this.endLoader();
     });
   },

--- a/src/views/ResourceManagement/Power/TablePowerPerformanceModes.vue
+++ b/src/views/ResourceManagement/Power/TablePowerPerformanceModes.vue
@@ -21,16 +21,16 @@ export default {
       ],
       items: [
         {
-          setting: this.$t('pagePower.selectMode.static'),
-          description: this.$t('pagePower.tableRoles.descStatic'),
-        },
-        {
-          setting: this.$t('pagePower.selectMode.powerSaving'),
-          description: this.$t('pagePower.tableRoles.descPowerSaving'),
-        },
-        {
-          setting: this.$t('pagePower.selectMode.maximumPerformance'),
+          setting: this.$t('pagePower.selectMode.maximumPerformance.primary'),
           description: this.$t('pagePower.tableRoles.descMaximumPerformance'),
+        },
+        {
+          setting: this.$t('pagePower.selectMode.energyEfficient.primary'),
+          description: this.$t('pagePower.tableRoles.descEnergyEfficient'),
+        },
+        {
+          setting: this.$t('pagePower.selectMode.maximumEnergySaver.primary'),
+          description: this.$t('pagePower.tableRoles.descMaximumEnergySaver'),
         },
       ],
     };


### PR DESCRIPTION
 - Static mode is no longer supported. Added a new power mode - Energy efficient(Efficiency favor power). Idle power saver can only be enabled/disabled/changed by user when the system is in Maximum performance mode. Also added support when the system is running in a custom mode. Each power mode in GUI now has a primary and secondary(displayed using an info tooltip) name.

 - Jira: https://jsw.ibm.com/browse/PFEBMC-1483