### PR TITLE
Memory page warning alert fix

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -1155,7 +1155,7 @@
     "updateDynamicIoDrawerAttachment": "Update dynamic I/O drawer attachment",
     "alert": {
       "heading": "Applying changes",
-      "message": "System has to be powered off and not managed by HMC. Changes made will take effect on next reboot.",
+      "message": "System has to be powered off. Changes made will take effect on next reboot.",
       "serverMustBePoweredOffTo": "Server must be powered off to:",
       "updateActiveMemoryMirroring": "Update active memory mirror mode",
       "updateIoAdapterEnlargedCapacity": "@:pageMemory.updateIoAdapterEnlargedCapacity",


### PR DESCRIPTION
 - Removed "not managed by HMC" from warning alert message in Memory page.

 - Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=670664