### PR TITLE
Remove browser reload message

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -383,10 +383,8 @@
       "errorDeleteCertificate": "Error deleting certificate.",
       "errorReplaceCertificate": "Error replacing certificate.",
       "successAddCertificate": "Successfully added %{certificate}.",
-      "successAddedHTTPCertificate": "Successfully added %{certificate}. Reload the browser page to see the changes.",
       "successDeleteCertificate": "Successfully deleted %{certificate}.",
-      "successReplaceCertificate": "Successfully replaced %{certificate}.",
-      "successReplacedHTTPCertificate": "Successfully replaced %{certificate}. Reload the browser page to see the changes."
+      "successReplaceCertificate": "Successfully replaced %{certificate}."
     }
   },
   "pageChangePassword": {

--- a/src/store/modules/SecurityAndAccess/CertificatesStore.js
+++ b/src/store/modules/SecurityAndAccess/CertificatesStore.js
@@ -211,21 +211,9 @@ export const CertificatesStore = defineStore('certificates', {
         })
         .then(() => this.getCertificates())
         .then(() => {
-          if (typeOfCertificate === 'HTTPS Certificate') {
-            return i18n.global.t(
-              'pageCertificates.toast.successAddedHTTPCertificate',
-              {
-                certificate: getCertificateProp(type, 'label'),
-              }
-            );
-          } else {
-            return i18n.global.t(
-              'pageCertificates.toast.successAddCertificate',
-              {
-                certificate: getCertificateProp(type, 'label'),
-              }
-            );
-          }
+          return i18n.global.t('pageCertificates.toast.successAddCertificate', {
+            certificate: getCertificateProp(type, 'label'),
+          });
         })
         .catch((error) => {
           console.log(error);
@@ -281,21 +269,12 @@ export const CertificatesStore = defineStore('certificates', {
           this.getCertificates();
         })
         .then(() => {
-          if (typeOfCertificate === 'HTTPS Certificate') {
-            return i18n.global.t(
-              'pageCertificates.toast.successReplacedHTTPCertificate',
-              {
-                certificate: getCertificateProp(type, 'label'),
-              }
-            );
-          } else {
-            return i18n.global.t(
-              'pageCertificates.toast.successReplaceCertificate',
-              {
-                certificate: getCertificateProp(type, 'label'),
-              }
-            );
-          }
+          return i18n.global.t(
+            'pageCertificates.toast.successReplaceCertificate',
+            {
+              certificate: getCertificateProp(type, 'label'),
+            }
+          );
         })
         .catch((error) => {
           console.log(error);


### PR DESCRIPTION
 - Vue 3 codebase can now fetch the updated certificate list without requiring a browser reload from the user.

 - Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=670841