### PR TITLE
Fix Content-Type in request header

### DIFF
--- a/src/store/modules/SecurityAndAccess/CertificatesStore.js
+++ b/src/store/modules/SecurityAndAccess/CertificatesStore.js
@@ -158,7 +158,7 @@ export const CertificatesStore = defineStore('certificates', {
       };
       return await api
         .patch(getCertificateProp(type, 'location'), fileObj, {
-          headers: { 'Content-Type': 'application/octet-stream' },
+          headers: { 'Content-Type': 'application/json' },
         })
         .then(() => {
           this.getAcfCertificate();
@@ -189,7 +189,7 @@ export const CertificatesStore = defineStore('certificates', {
       };
       return await api
         .patch(getCertificateProp(type, 'location'), fileObj, {
-          headers: { 'Content-Type': 'application/octet-stream' },
+          headers: { 'Content-Type': 'application/json' },
         })
         .then(() =>
           i18n.global.t('pageCertificates.toast.successAddCertificate', {
@@ -247,7 +247,7 @@ export const CertificatesStore = defineStore('certificates', {
       };
       return await api
         .patch(location, fileObj, {
-          headers: { 'Content-Type': 'application/octet-stream' },
+          headers: { 'Content-Type': 'application/json' },
         })
         .then(() => {
           this.getAcfCertificate();


### PR DESCRIPTION
 - Content-Type should be json instead of octet-stream for these requests.

 - Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=671019