### PR TITLE
Vue3: Add error toast message when CSR generation fails

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -382,6 +382,7 @@
       "errorAddCertificate": "Error adding certificate.",
       "errorDeleteCertificate": "Error deleting certificate.",
       "errorReplaceCertificate": "Error replacing certificate.",
+      "errorGenerateCsr": "Error generating CSR.",
       "successAddCertificate": "Successfully added %{certificate}.",
       "successAddedHTTPCertificate": "Successfully added %{certificate}. Reload the browser page to see the changes.",
       "successDeleteCertificate": "Successfully deleted %{certificate}.",

--- a/src/store/modules/SecurityAndAccess/CertificatesStore.js
+++ b/src/store/modules/SecurityAndAccess/CertificatesStore.js
@@ -384,7 +384,12 @@ export const CertificatesStore = defineStore('certificates', {
         )
         //TODO: Success response also throws error so
         // can't accurately show legitimate error in UI
-        .catch((error) => console.log(error));
+        .catch((error) => {
+          console.log(error);
+          throw new Error(
+            i18n.global.t('pageCertificates.toast.errorGenerateCsr')
+          );
+        });
     },
   },
 });

--- a/src/views/SecurityAndAccess/Certificates/ModalGenerateCsr.vue
+++ b/src/views/SecurityAndAccess/Certificates/ModalGenerateCsr.vue
@@ -355,10 +355,13 @@ import { CertificatesStore } from '@/store';
 
 import IconAdd from '@carbon/icons-vue/es/add--alt/20';
 
+import useToast from '@/components/Composables/useToastComposable';
 import { COUNTRY_LIST } from './CsrCountryCodes';
 import { CERTIFICATE_TYPES } from '@/store/modules/SecurityAndAccess/CertificatesStore';
 import useVuelidateComposable from '@/components/Composables/useVuelidateComposable';
 import eventBus from '@/eventBus';
+
+const { errorToast } = useToast();
 
 const { getValidationState } = useVuelidateComposable();
 const openCsrModal = ref(false);
@@ -432,12 +435,15 @@ const modal = ref(false);
 const handleSubmit = () => {
   v$.value.$touch();
   if (v$.value.$invalid) return;
-  uploadCertificate.generateCsr(form.value).then(({ data: { CSRString } }) => {
-    csrString.value = CSRString;
-    modal.value = false;
-    openCsrModal.value = true;
-    v$.value.form.$reset();
-  });
+  uploadCertificate
+    .generateCsr(form.value)
+    .then(({ data: { CSRString } }) => {
+      csrString.value = CSRString;
+      modal.value = false;
+      openCsrModal.value = true;
+      v$.value.form.$reset();
+    })
+    .catch(({ message }) => errorToast(message));
 };
 
 const resetCsr = () => {


### PR DESCRIPTION
 - Read-only user will now see a error toast message when trying to generate a CSR.

 - Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=671025