### PR TITLE
Add error toast message when CSR generation fails

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -382,6 +382,7 @@
       "errorAddCertificate": "Error adding certificate.",
       "errorDeleteCertificate": "Error deleting certificate.",
       "errorReplaceCertificate": "Error replacing certificate.",
+      "errorGenerateCsr": "Error generating CSR.",
       "successAddCertificate": "Successfully added %{certificate}.",
       "successAddedHTTPCertificate": "Successfully added %{certificate}. Reload the browser page to see the changes.",
       "successDeleteCertificate": "Successfully deleted %{certificate}.",

--- a/src/store/modules/SecurityAndAccess/CertificatesStore.js
+++ b/src/store/modules/SecurityAndAccess/CertificatesStore.js
@@ -382,7 +382,10 @@ const CertificatesStore = {
         )
         //TODO: Success response also throws error so
         // can't accurately show legitimate error in UI
-        .catch((error) => console.log(error));
+        .catch((error) => {
+          console.log(error);
+          throw new Error(i18n.t('pageCertificates.toast.errorGenerateCsr'));
+        });
     },
   },
 };

--- a/src/views/SecurityAndAccess/Certificates/ModalGenerateCsr.vue
+++ b/src/views/SecurityAndAccess/Certificates/ModalGenerateCsr.vue
@@ -448,7 +448,8 @@ export default {
           this.csrString = CSRString;
           this.$bvModal.show('csr-string');
           this.$v.$reset();
-        });
+        })
+        .catch(({ message }) => this.errorToast(message));
     },
     resetForm() {
       for (let key of Object.keys(this.form)) {


### PR DESCRIPTION
 - Read-only user will now see a error toast message when trying to generate a CSR.

 - Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=671025