### PR TITLE
Fixed event id issue on Hardware deconfiguration page

### DIFF
--- a/src/store/modules/Settings/HardwareDeconfigurationStore.js
+++ b/src/store/modules/Settings/HardwareDeconfigurationStore.js
@@ -50,7 +50,7 @@ const HardwareDeconfigurationStore = {
           if (Array.isArray(messageArgsArray) && messageArgsArray.length) {
             msgArgs = messageArgsArray[0];
           }
-          const logEntry = conditionsArray[0].LogEntry;
+          const logEntry = data['/Status/Conditions/0/LogEntry'];
           if (logEntry) {
             const eventIdUrl = logEntry['@odata.id'];
             const splitUrl = eventIdUrl.split('/');


### PR DESCRIPTION
- Event id now getting updated for deconfigured core on Hardeware deconfiguration page
- Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=670225