### PR TITLE
Revert "Removed compression Plugin. (#273)"

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -1,3 +1,5 @@
+const CompressionPlugin = require('compression-webpack-plugin');
+
 module.exports = {
   css: {
     loaderOptions: {
@@ -82,6 +84,14 @@ module.exports = {
           './AppNavigationMixin$'
         ] = `@/env/components/AppNavigation/${envName}.js`;
       }
+    }
+
+    if (process.env.NODE_ENV === 'production') {
+      config.plugins.push(
+        new CompressionPlugin({
+          deleteOriginalAssets: true,
+        })
+      );
     }
   },
   pluginOptions: {


### PR DESCRIPTION
This reverts commit 80efa3a14bc8cda4d5b3775f6f38ed39e1410d29.

We moved away from gzipping the logos/etc and broke the changeLogo script. Revert the commit that did that.

https://github.com/ibm-openbmc/webui-vue/pull/273 was added due to a false positive in a scanning tool.

```
root@p10bmc:~# cat `which changeLogo.sh`

model=($(busctl get-property xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system xyz.openbmc_project.Inventory.Decorator.Asset SubModel))
DIR=/usr/share/www/img
if [ "${model[1]}" = '"S0"' ]  || [ "${model[1]}" = '"D0"' ]; then
    echo "Using IBM logo"
elif [ "${model[1]}" = '"J0"' ]; then
    echo "loading IPS logo"
    mount --bind ${DIR}/inspur-login-logo.svg.gz ${DIR}/login-company-logo.svg.gz
    mount --bind ${DIR}/inspur-logo-header.svg.gz ${DIR}/logo-header.svg.gz
    mount --bind ${DIR}/blankLogo.svg.gz  /usr/share/www/bee-2-light.svg.gz
else
    echo "loading OEM logo"
    mount --bind ${DIR}/blankLogo.svg.gz ${DIR}/login-company-logo.svg.gz
    mount --bind ${DIR}/blankLogo.svg.gz ${DIR}/logo-header.svg.gz
    mount --bind ${DIR}/blankLogo.svg.gz  /usr/share/www/bee-2-light.svg.gz
fi
```

```
root@p10bmc:~# busctl get-property xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system xyz.openbmc_project.Inventory.Decorator.Asset SubModel
s "J0"

root@p10bmc:~# changeLogo.sh
loading IPS logo
mount: /usr/share/www/img/login-company-logo.svg.gz: mount point does not exist.
       dmesg(1) may have more information after failed mount system call.
```

Tested:
Without this revert
$ ls -l  dist/img/
total 8
-rw-r--r-- 1 gmills gmills 1839 Jan 16 16:20 login-company-logo.svg -rw-r--r-- 1 gmills gmills 1839 Jan 16 16:20 logo-header.svg

With this revert:
 ls -l  dist/img/
total 8
-rw-r--r-- 1 gmills gmills 868 Jan 16 16:30 login-company-logo.svg.gz -rw-r--r-- 1 gmills gmills 869 Jan 16 16:30 logo-header.svg.gz