### PR TITLE
Fixed empty alert in deconfig records

### DIFF
--- a/src/views/Logs/DeconfigurationRecords/DeconfigurationRecords.vue
+++ b/src/views/Logs/DeconfigurationRecords/DeconfigurationRecords.vue
@@ -8,8 +8,8 @@
       :link="$t('pageDeconfigurationRecords.pageDescription.link')"
       to="/settings/hardware-deconfiguration"
     />
-    <alert variant="info" class="mb-4">
-      <p v-if="!isServerOff()">
+    <alert v-if="!isServerOff()" variant="info" class="mb-4">
+      <p>
         {{ $t('pageDeconfigurationRecords.alertPowerOff') }}
       </p>
     </alert>


### PR DESCRIPTION
- Used to get an empty alert message when the system is powered off.