### PR TITLE
Overview page OEM/Custom mode fix

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -475,8 +475,7 @@
       "errorConfiguringProcessorCore": "Error Configuring Processor Core",
       "errorConfiguringDIMM": "Error Configuring Memory DIMM",
       "errorDeconfiguringProcessorCore": "Error Deconfiguring Processor Core",
-      "errorDeconfiguringDIMM" : "Error Deconfiguring Memory DIMM"
-    
+      "errorDeconfiguringDIMM": "Error Deconfiguring Memory DIMM"
     },
     "table": {
       "deconfigurationType": "Deconfiguration Type",
@@ -1448,6 +1447,7 @@
       "message3Link": "server power operations"
     },
     "oemMode": {
+      "primary": "Custom mode",
       "message1": "System is currently in a custom mode.",
       "message2": "Change mode by selecting an option below."
     },

--- a/src/views/Overview/OverviewPower.vue
+++ b/src/views/Overview/OverviewPower.vue
@@ -39,6 +39,9 @@
           <dd v-else-if="powerPerformanceMode === 'PowerSaving'">
             {{ $t('pagePower.selectMode.maximumEnergySaver.primary') }}
           </dd>
+          <dd v-else-if="powerPerformanceMode === 'OEM'">
+            {{ $t('pagePower.oemMode.primary') }}
+          </dd>
         </dl>
       </b-col>
     </b-row>


### PR DESCRIPTION
 - Overview page was not showing power mode when the system was in OEM/Custom power mode.

 - Fixes: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=673956

Before:
![ClipboardImage_20250127030947(1)](https://github.com/user-attachments/assets/335ea905-ddda-4528-bed9-0659ee5566d5)

After:
![Screenshot 2025-01-28 at 10 38 00 AM](https://github.com/user-attachments/assets/2e1790e7-a339-40f7-91ad-b42d1876606c)
