### PR TITLE
Fixed Clear all Deconfig records

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -553,6 +553,8 @@
       "spare": "Spare"
     },
     "toast": {
+      "clearAllInfo": "Core guard records will be not be deleted as it might be associated with Spare core.",
+      "clearAllSuccess": "Successfully initiated Clear all",
       "errorDelete": "Error deleting %{count} record. | Error deleting %{count} records.",
       "errorResolveEntries": "Error resolving %{count} record. | Error resolving %{count} records.",
       "errorStartDownload": "Error starting download.",

--- a/src/views/Logs/DeconfigurationRecords/DeconfigurationRecords.vue
+++ b/src/views/Logs/DeconfigurationRecords/DeconfigurationRecords.vue
@@ -412,7 +412,14 @@ export default {
                 'deconfigurationRecords/clearAllEntries',
                 this.allEntries
               )
-              .then((message) => this.successToast(message))
+              .then(() => {
+                this.infoToast(
+                  this.$tc('pageDeconfigurationRecords.toast.clearAllInfo')
+                );
+                this.successToast(
+                  this.$tc('pageDeconfigurationRecords.toast.clearAllSuccess')
+                );
+              })
               .catch(({ message }) => this.errorToast(message));
           }
         });


### PR DESCRIPTION
- Displaying a generic message for clear all records in Deconfig records page.
- Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=671125