### PR TITLE
Clear previous user's storedCurrentUser data

### DIFF
--- a/src/store/modules/GlobalStore.js
+++ b/src/store/modules/GlobalStore.js
@@ -138,7 +138,6 @@ const GlobalStore = {
       { commit, dispatch, getters },
       username = localStorage.getItem('storedUsername')
     ) {
-      if (localStorage.getItem('storedCurrentUser')) return;
       return api
         .get(`/redfish/v1/AccountService/Accounts/${username}`)
         .then(({ data }) => {


### PR DESCRIPTION
 - storedCurrentUser from local storage was only cleared when a user logs out. This will can cause the new logged in user to use previous logged user's storedCurrentUser local storage data when they did not logout.

 - Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=674716