### PR TITLE
Add table refresh when request fails

### DIFF
--- a/src/store/api.js
+++ b/src/store/api.js
@@ -33,12 +33,9 @@ api.interceptors.response.use(undefined, (error) => {
     // Toast error message will appear on screen
     // when the action is unauthorized.
     // Hardware deconfiguration is an exception to this
-    const url = response.config.url;
+
     const notGetMethod = response.config.method !== 'get';
-    const coreUrl = 'redfish/v1/Systems/system/Processors';
-    const memoryUrl = 'redfish/v1/Systems/system/Memory';
-    if (!(url.includes(coreUrl) || url.includes(memoryUrl)) && notGetMethod)
-      store.commit('global/setUnauthorized');
+    if (notGetMethod) store.commit('global/setUnauthorized');
   }
 
   return Promise.reject(error);

--- a/src/store/modules/HardwareStatus/AssemblyStore.js
+++ b/src/store/modules/HardwareStatus/AssemblyStore.js
@@ -68,7 +68,7 @@ const AssemblyStore = {
           }
         })
         .catch((error) => {
-          dispatch('getAssemblyInfo');
+          dispatch('getAssemblyInfo', { uri: '/redfish/v1/Chassis/chassis' });
           console.log('error', error);
           if (led.identifyLed) {
             throw new Error(

--- a/src/store/modules/HardwareStatus/FabricAdaptersStore.js
+++ b/src/store/modules/HardwareStatus/FabricAdaptersStore.js
@@ -89,7 +89,9 @@ const FabricAdaptersStore = {
           }
         })
         .catch((error) => {
-          dispatch('getFabricAdaptersInfo');
+          dispatch('getFabricAdaptersInfo', {
+            uri: '/redfish/v1/Chassis/chassis',
+          });
           console.log('error', error);
           if (led.identifyLed) {
             throw new Error(

--- a/src/store/modules/HardwareStatus/FanStore.js
+++ b/src/store/modules/HardwareStatus/FanStore.js
@@ -58,7 +58,7 @@ const FanStore = {
         })
         .catch((error) => console.log(error));
     },
-    async updateIdentifyLedValue(_, led) {
+    async updateIdentifyLedValue({ dispatch }, led) {
       const uri = led.uri;
       const updatedIdentifyLedValue = {
         LocationIndicatorActive: led.identifyLed,
@@ -73,6 +73,7 @@ const FanStore = {
           }
         })
         .catch((error) => {
+          dispatch('getAllFans', { uri: '/redfish/v1/Chassis/chassis' });
           console.log(error);
           if (led.identifyLed) {
             throw new Error(

--- a/src/store/modules/HardwareStatus/PowerSupplyStore.js
+++ b/src/store/modules/HardwareStatus/PowerSupplyStore.js
@@ -62,7 +62,7 @@ const PowerSupplyStore = {
         })
         .catch((error) => console.log(error));
     },
-    async updateIdentifyLedValue(_, led) {
+    async updateIdentifyLedValue({ dispatch }, led) {
       const uri = led.uri;
       const updatedIdentifyLedValue = {
         LocationIndicatorActive: led.identifyLed,
@@ -77,6 +77,9 @@ const PowerSupplyStore = {
           }
         })
         .catch((error) => {
+          dispatch('getAllPowerSupplies', {
+            uri: '/redfish/v1/Chassis/chassis',
+          });
           console.log(error);
           if (led.identifyLed) {
             throw new Error(

--- a/src/views/ResourceManagement/FieldCoreOverride/FieldCoreOverrideConfiguration.vue
+++ b/src/views/ResourceManagement/FieldCoreOverride/FieldCoreOverrideConfiguration.vue
@@ -80,10 +80,7 @@ export default {
       systems: 'system/systems',
     }),
     maxConfiguredCores() {
-      return Math.min(
-        this.systems?.[0]?.processorSummaryCoreCount,
-        this.processorInfo?.PermProcs?.MaxAuthorizedDevices
-      );
+      return this.systems?.[0]?.processorSummaryCoreCount;
     },
   },
   watch: {


### PR DESCRIPTION
- Inventory LEDs table where not updating on request failure for read-only user. Added requests to update the table in catch block.

- Removed memory and processor checks in api.js as they are redundant.

- Fixes: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=675877 and https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=675881