### PR TITLE
Fixed User ID and Group ID attribute default value

### DIFF
--- a/src/store/modules/SecurityAndAccess/LdapStore.js
+++ b/src/store/modules/SecurityAndAccess/LdapStore.js
@@ -164,13 +164,11 @@ const LdapStore = {
         LDAPService: {
           SearchSettings: {
             BaseDistinguishedNames: [baseDn],
+            GroupsAttribute: groupIdAttribute,
+            UsernameAttribute: userIdAttribute,
           },
         },
       };
-      if (groupIdAttribute)
-        data.LDAPService.SearchSettings.GroupsAttribute = groupIdAttribute;
-      if (userIdAttribute)
-        data.LDAPService.SearchSettings.UsernameAttribute = userIdAttribute;
 
       if (activeDirectoryEnabled) {
         return await dispatch('saveActiveDirectorySettings', data);


### PR DESCRIPTION
- Fixed User ID and Group ID attribute default value under LDAP when entry saved as blank.
- Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=680675

Signe-off-by: Vedangi Mittal <vedangimittal3004@gmail.com>