### PR TITLE
Updated auto hide delay for success toast

### DIFF
--- a/src/components/Composables/useToastComposable.js
+++ b/src/components/Composables/useToastComposable.js
@@ -7,16 +7,14 @@ const useToastComposable = () => {
   const initToast = (title, body, statusPassed, timestamp, refreshAction) => {
     show?.({
       props: () => ({
-        // value: true,
-        interval: 60000,
+        //Success toast autoHideDelay - 10 seconds, Error/Info toast autohidedelay - 30 minutes
+        interval: statusPassed==="success" ? 10000 : 1800000, 
       }),
       component: h(Toast, {
         title: title,
         body: body,
         statusPassed: statusPassed,
         pos: 'top-right',
-        // autoHideDelay: 10000,
-        // autoHide: false,
         timestamp: timestamp,
         refreshAction: refreshAction,
       }),

--- a/src/components/Global/Toast.vue
+++ b/src/components/Global/Toast.vue
@@ -33,7 +33,6 @@ const { title, body, statusPassed, timestamp, refreshAction } = defineProps({
   body: String,
   // eslint-disable-next-line vue/require-default-prop
   statusPassed: String,
-  autoHide: Boolean,
   timestamp: Boolean,
   refreshAction: Boolean,
 });


### PR DESCRIPTION
- The auto-hide delay for the success toast has been updated to 10 seconds, while the delay for other toasts (error and info) is set to 30 minutes.
- Defect- https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=670062