### PR TITLE
Updated Overview page - power mode section

### DIFF
--- a/src/views/Overview/OverviewPower.vue
+++ b/src/views/Overview/OverviewPower.vue
@@ -30,17 +30,14 @@
             <status-icon status="danger" />
             {{ $t('pageOverview.safeMode') }}
           </dd>
+          <dd v-else-if="powerPerformanceMode === 'Static'">
+            {{ $t('pageOverview.powerPerformanceModes.static') }}
+          </dd>
           <dd v-else-if="powerPerformanceMode === 'MaximumPerformance'">
             {{ $t('pageOverview.powerPerformanceModes.maximumPerformance') }}
           </dd>
-          <dd v-else-if="powerPerformanceMode === 'EfficiencyFavorPower'">
-            {{ $t('pagePower.selectMode.energyEfficient.primary') }}
-          </dd>
           <dd v-else-if="powerPerformanceMode === 'PowerSaving'">
-            {{ $t('pagePower.selectMode.maximumEnergySaver.primary') }}
-          </dd>
-          <dd v-else-if="powerPerformanceMode === 'OEM'">
-            {{ $t('pagePower.oemMode.primary') }}
+            {{ $t('pageOverview.powerPerformanceModes.powerSaving') }}
           </dd>
         </dl>
       </b-col>


### PR DESCRIPTION
- Updated power mode section under overview page. Removed OEM mode as its not required in 1060
- Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=699309