### PR TITLE
Refetch Event logs on error

### DIFF
--- a/src/views/Logs/EventLogs/EventLogs.vue
+++ b/src/views/Logs/EventLogs/EventLogs.vue
@@ -524,10 +524,10 @@ export default {
           status: row.status,
         })
         .then((success) => {
-          this.reloadEventLogData();
           this.successToast(success);
         })
-        .catch(({ message }) => this.errorToast(message));
+        .catch(({ message }) => this.errorToast(message))
+        .finally(() => this.reloadEventLogData());
     },
     resolutionValue(item) {
       let value = item?.resolution?.split('\n');


### PR DESCRIPTION
- On error of resolving a single Event log, the toggle updates its state.  Updated to refetch the latest redfish value.
- Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=707148