### PR TITLE
1060: Updated Power cap value in Overview

### DIFF
--- a/src/views/Overview/OverviewPower.vue
+++ b/src/views/Overview/OverviewPower.vue
@@ -12,7 +12,7 @@
           </dd>
           <dd v-else>{{ powerConsumptionValue }} W</dd>
           <dt>{{ $t('pageOverview.powerCap') }}</dt>
-          <dd v-if="!powerCapValue">
+          <dd v-if="!isPowerCapEnabled || !powerCapValue">
             {{ $t('global.status.disabled') }}
           </dd>
           <dd v-else>{{ powerCapValue }} W</dd>
@@ -61,6 +61,7 @@ export default {
   computed: {
     ...mapGetters({
       idlePowerSaverData: 'powerControl/idlePowerSaverData',
+      isPowerCapEnabled: 'powerControl/isPowerCapEnabled',
       powerCapValue: 'powerControl/powerCap',
       powerConsumptionValue: 'powerControl/powerConsumption',
       powerPerformanceMode: 'powerControl/powerPerformanceMode',


### PR DESCRIPTION
- When the Power cap value is disabled in Power page, the value in Overview Power cap should be “Disabled”
- Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=715687