### PR TITLE
New validation for ACF certificates

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -371,6 +371,7 @@
       "keyBitLength": "Key bit length",
       "keyCurveId": "Key curve ID",
       "keyPairAlgorithm": "Key pair algorithm",
+      "mismatchError": "Uploaded certificate does not match selected Certificate type.",
       "privateKey": "Private key",
       "state": "State"
     },

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -335,6 +335,7 @@
   },
   "pageCertificates": {
     "addNewCertificate": "Add new certificate",
+    "adminResetCertificate": "Admin reset certificate",
     "bmcShell": "BMC shell ACF certificate",
     "caCertificate": "CA Certificate",
     "deleteCertificate": "Delete certificate",

--- a/src/store/modules/SecurityAndAccess/CertificatesStore.js
+++ b/src/store/modules/SecurityAndAccess/CertificatesStore.js
@@ -32,13 +32,19 @@ export const CERTIFICATE_TYPES = [
     type: 'BMC shell ACF certificate',
     location: '/redfish/v1/AccountService/Accounts/service',
     label: i18n.t('pageCertificates.bmcShell'),
-    limit: 100,
+    limit: 100, // This limit doesn't affect this certificate type
   },
   {
     type: 'Resource dump ACF certificate',
     location: '/redfish/v1/AccountService/Accounts/service',
     label: i18n.t('pageCertificates.resourceDump'),
-    limit: 100,
+    limit: 100, // This limit doesn't affect this certificate type
+  },
+  {
+    type: 'Admin reset certificate',
+    location: '/redfish/v1/AccountService/Accounts/service',
+    label: i18n.t('pageCertificates.adminResetCertificate'),
+    limit: 100, // This limit doesn't affect this certificate type
   },
 ];
 const getCertificateProp = (type, prop) => {

--- a/src/views/Login/ModalUploadCertificate.vue
+++ b/src/views/Login/ModalUploadCertificate.vue
@@ -103,6 +103,11 @@ export default {
         this.form.certificateType = options[0].value;
       }
     },
+    'form.certificateType'(newValue) {
+      if (newValue) {
+        this.$v.form.file.$reset();
+      }
+    },
   },
   mounted() {
     this.form.certificateType = this.certificateOptions[0]?.value;
@@ -170,6 +175,10 @@ export default {
               this.$v.form.file.$touch();
               return;
             }
+          } else {
+            this.fileTypeMismatch = true;
+            this.$v.form.file.$touch();
+            return;
           }
           this.$emit('ok', {
             type: this.form.certificateType,

--- a/src/views/Login/ModalUploadCertificate.vue
+++ b/src/views/Login/ModalUploadCertificate.vue
@@ -76,6 +76,10 @@ export default {
           value: this.$t('pageCertificates.serviceLoginCertificate'),
         },
         {
+          text: 'Admin reset certificate',
+          value: this.$t('pageCertificates.adminResetCertificate'),
+        },
+        {
           text: 'BMC shell ACF certificate',
           value: this.$t('pageCertificates.bmcShell'),
         },
@@ -152,6 +156,14 @@ export default {
             }
           } else if (decoded.includes('service')) {
             if (this.form.certificateType === 'ServiceLogin Certificate') {
+              this.fileTypeMismatch = false;
+            } else {
+              this.fileTypeMismatch = true;
+              this.$v.form.file.$touch();
+              return;
+            }
+          } else if (decoded.includes('adminreset')) {
+            if (this.form.certificateType === 'Admin reset certificate') {
               this.fileTypeMismatch = false;
             } else {
               this.fileTypeMismatch = true;

--- a/src/views/Login/ModalUploadCertificate.vue
+++ b/src/views/Login/ModalUploadCertificate.vue
@@ -30,8 +30,14 @@
           @change="onFileChange($event)"
         >
           <template #invalid>
-            <b-form-invalid-feedback role="alert">
+            <b-form-invalid-feedback v-if="!$v.form.file.required" role="alert">
               {{ $t('global.form.required') }}
+            </b-form-invalid-feedback>
+            <b-form-invalid-feedback
+              v-else-if="!$v.form.file.fileMatchesType"
+              role="alert"
+            >
+              {{ $t('pageCertificates.modal.mismatchError') }}
             </b-form-invalid-feedback>
           </template>
         </form-file>
@@ -59,6 +65,7 @@ export default {
         certificateType: null,
         file: null,
       },
+      fileTypeMismatch: false,
     };
   },
   computed: {
@@ -80,6 +87,13 @@ export default {
     },
   },
   watch: {
+    'form.file'(newFile) {
+      if (newFile) {
+        this.fileTypeMismatch = false;
+        this.$v.form.file.$reset();
+        this.$v.form.file.$touch();
+      }
+    },
     certificateOptions: function (options) {
       if (options.length) {
         this.form.certificateType = options[0].value;
@@ -99,6 +113,7 @@ export default {
         },
         file: {
           required,
+          fileMatchesType: this.validateFileMatchesType,
         },
       },
     };
@@ -108,13 +123,52 @@ export default {
       this.attachment.file = event.target.files[0];
     },
     handleSubmit() {
+      this.fileTypeMismatch = false;
       this.$v.$touch();
       if (this.$v.$invalid) return;
-      this.$emit('ok', {
-        type: this.form.certificateType,
-        file: this.form.file,
-      });
-      this.closeModal();
+      const file = this.form.file;
+      const reader = new FileReader();
+
+      reader.onload = () => {
+        try {
+          const base64String = reader.result;
+          const cleanBase64 = base64String.replace(/^data:.*;base64,/, '');
+          const decoded = atob(cleanBase64);
+          if (decoded.includes('resourcedump')) {
+            if (this.form.certificateType === 'Resource dump ACF certificate') {
+              this.fileTypeMismatch = false;
+            } else {
+              this.fileTypeMismatch = true;
+              this.$v.form.file.$touch();
+              return;
+            }
+          } else if (decoded.includes('bmcshell')) {
+            if (this.form.certificateType === 'BMC shell ACF certificate') {
+              this.fileTypeMismatch = false;
+            } else {
+              this.fileTypeMismatch = true;
+              this.$v.form.file.$touch();
+              return;
+            }
+          } else if (decoded.includes('service')) {
+            if (this.form.certificateType === 'ServiceLogin Certificate') {
+              this.fileTypeMismatch = false;
+            } else {
+              this.fileTypeMismatch = true;
+              this.$v.form.file.$touch();
+              return;
+            }
+          }
+          this.$emit('ok', {
+            type: this.form.certificateType,
+            file: this.form.file,
+          });
+          this.closeModal();
+        } catch (error) {
+          console.error('Error during file processing:', error);
+        }
+      };
+      reader.readAsDataURL(file);
     },
     closeModal() {
       this.$nextTick(() => {
@@ -123,11 +177,16 @@ export default {
     },
     resetForm() {
       (this.form.certificateType = null), (this.form.file = null);
+      this.fileTypeMismatch = false;
       this.$v.$reset();
     },
     onOk(bvModalEvt) {
       bvModalEvt.preventDefault();
       this.handleSubmit();
+    },
+    validateFileMatchesType() {
+      if (!this.$v.form.file.$dirty) return true;
+      return !this.fileTypeMismatch;
     },
   },
 };

--- a/src/views/SecurityAndAccess/Certificates/ModalGenerateCsr.vue
+++ b/src/views/SecurityAndAccess/Certificates/ModalGenerateCsr.vue
@@ -393,7 +393,10 @@ export default {
       certificateOptions: CERTIFICATE_TYPES.reduce((arr, cert) => {
         if (
           cert.type === 'TrustStore Certificate' ||
-          cert.type === 'ServiceLogin Certificate'
+          cert.type === 'ServiceLogin Certificate' ||
+          cert.type === 'Admin reset certificate' ||
+          cert.type === 'BMC shell ACF certificate' ||
+          cert.type === 'Resource dump ACF certificate'
         )
           return arr;
         arr.push({

--- a/src/views/SecurityAndAccess/Certificates/ModalUploadCertificate.vue
+++ b/src/views/SecurityAndAccess/Certificates/ModalUploadCertificate.vue
@@ -204,6 +204,11 @@ export default {
         this.form.certificateType = options[0].value;
       }
     },
+    'form.certificateType'(newValue) {
+      if (newValue) {
+        this.$v.form.file.$reset();
+      }
+    },
   },
   validations() {
     return {
@@ -264,6 +269,10 @@ export default {
                 this.$v.form.file.$touch();
                 return;
               }
+            } else {
+              this.fileTypeMismatch = true;
+              this.$v.form.file.$touch();
+              return;
             }
             this.$emit('ok', {
               addNew: !this.certificate,

--- a/src/views/SecurityAndAccess/Certificates/ModalUploadCertificate.vue
+++ b/src/views/SecurityAndAccess/Certificates/ModalUploadCertificate.vue
@@ -63,8 +63,17 @@
             :state="getValidationState($v.form.file)"
           >
             <template #invalid>
-              <b-form-invalid-feedback role="alert">
+              <b-form-invalid-feedback
+                v-if="!$v.form.file.required"
+                role="alert"
+              >
                 {{ $t('global.form.required') }}
+              </b-form-invalid-feedback>
+              <b-form-invalid-feedback
+                v-else-if="!$v.form.file.fileMatchesType"
+                role="alert"
+              >
+                {{ $t('pageCertificates.modal.mismatchError') }}
               </b-form-invalid-feedback>
             </template>
           </form-file>
@@ -132,6 +141,7 @@ export default {
         certificateType: null,
         file: null,
       },
+      fileTypeMismatch: false,
     };
   },
   computed: {
@@ -179,6 +189,13 @@ export default {
     },
   },
   watch: {
+    'form.file'(newFile) {
+      if (newFile) {
+        this.fileTypeMismatch = false;
+        this.$v.form.file.$reset();
+        this.$v.form.file.$touch();
+      }
+    },
     certificateOptions: function (options) {
       if (options.length) {
         this.form.certificateType = options[0].value;
@@ -195,23 +212,81 @@ export default {
         },
         file: {
           required,
+          fileMatchesType: this.validateFileMatchesType,
         },
       },
     };
   },
   methods: {
     handleSubmit() {
+      this.fileTypeMismatch = false;
       this.$v.$touch();
       if (this.$v.$invalid) return;
-      this.$emit('ok', {
-        addNew: !this.certificate,
-        file: this.form.file,
-        location: this.certificate ? this.certificate.location : null,
-        type: this.certificate
-          ? this.certificate.certificate
-          : this.form.certificateType,
-      });
-      this.closeModal();
+      if (
+        this.form.certificateType === 'BMC shell ACF certificate' ||
+        this.form.certificateType === 'Resource dump ACF certificate' ||
+        this.form.certificateType === 'ServiceLogin Certificate'
+      ) {
+        const file = this.form.file;
+        const reader = new FileReader();
+
+        reader.onload = () => {
+          try {
+            const base64String = reader.result;
+            const cleanBase64 = base64String.replace(/^data:.*;base64,/, '');
+            const decoded = atob(cleanBase64);
+            if (decoded.includes('resourcedump')) {
+              if (
+                this.form.certificateType === 'Resource dump ACF certificate'
+              ) {
+                this.fileTypeMismatch = false;
+              } else {
+                this.fileTypeMismatch = true;
+                this.$v.form.file.$touch();
+                return;
+              }
+            } else if (decoded.includes('bmcshell')) {
+              if (this.form.certificateType === 'BMC shell ACF certificate') {
+                this.fileTypeMismatch = false;
+              } else {
+                this.fileTypeMismatch = true;
+                this.$v.form.file.$touch();
+                return;
+              }
+            } else if (decoded.includes('service')) {
+              if (this.form.certificateType === 'ServiceLogin Certificate') {
+                this.fileTypeMismatch = false;
+              } else {
+                this.fileTypeMismatch = true;
+                this.$v.form.file.$touch();
+                return;
+              }
+            }
+            this.$emit('ok', {
+              addNew: !this.certificate,
+              file: this.form.file,
+              location: this.certificate ? this.certificate.location : null,
+              type: this.certificate
+                ? this.certificate.certificate
+                : this.form.certificateType,
+            });
+            this.closeModal();
+          } catch (error) {
+            console.error('Error during file processing:', error);
+          }
+        };
+        reader.readAsDataURL(file);
+      } else {
+        this.$emit('ok', {
+          addNew: !this.certificate,
+          file: this.form.file,
+          location: this.certificate ? this.certificate.location : null,
+          type: this.certificate
+            ? this.certificate.certificate
+            : this.form.certificateType,
+        });
+        this.closeModal();
+      }
     },
     closeModal() {
       this.$nextTick(() => {
@@ -223,12 +298,17 @@ export default {
         ? this.certificateOptions[0].value
         : null;
       this.form.file = null;
+      this.fileTypeMismatch = false;
       this.$v.$reset();
     },
     onOk(bvModalEvt) {
       // prevent modal close
       bvModalEvt.preventDefault();
       this.handleSubmit();
+    },
+    validateFileMatchesType() {
+      if (!this.$v.form.file.$dirty) return true;
+      return !this.fileTypeMismatch;
     },
   },
 };

--- a/src/views/SecurityAndAccess/Certificates/ModalUploadCertificate.vue
+++ b/src/views/SecurityAndAccess/Certificates/ModalUploadCertificate.vue
@@ -151,6 +151,9 @@ export default {
     certificateOptions() {
       const filteredCertificates = this.certificateTypes
         .filter((certificate) => {
+          if (certificate.type === 'Admin reset certificate') {
+            return false;
+          }
           if (
             certificate.type === 'ServiceLogin Certificate' &&
             this.isNotAdmin


### PR DESCRIPTION
- Added validations to verify ACF certificates.
- Added support to select Admin reset certificate.
- Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=732202 and https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=732645