### PR TITLE
Updated Capacity on Demand page

### DIFF
--- a/src/views/ResourceManagement/CapacityOnDemand/CapacityOnDemandOrderInfo.vue
+++ b/src/views/ResourceManagement/CapacityOnDemand/CapacityOnDemandOrderInfo.vue
@@ -55,12 +55,6 @@
                 {{ $t('pageCapacityOnDemand.orderInfo.processorInfo') }}
               </h3>
               <p>
-                {{ $t('pageCapacityOnDemand.orderInfo.previousActivated') }}
-                <span class="font-weight-bold">
-                  {{ processorPreviousActivated }}
-                </span>
-              </p>
-              <p>
                 {{ $t('pageCapacityOnDemand.orderInfo.processorResourceId') }}
                 <span class="font-weight-bold">
                   {{ processorInfo.resourceId }}
@@ -81,12 +75,6 @@
                   {{ dataFormatter(processorLicensed) }}
                 </span>
               </p>
-              <p>
-                {{ $t('pageCapacityOnDemand.orderInfo.entryCheck') }}:
-                <span class="font-weight-bold">
-                  {{ processorEntryCheck }}
-                </span>
-              </p>
             </b-col>
           </b-row>
 
@@ -96,12 +84,6 @@
               <h3 class="h4 mb-3">
                 {{ $t('pageCapacityOnDemand.orderInfo.memoryInfo') }}
               </h3>
-              <p>
-                {{ $t('pageCapacityOnDemand.orderInfo.previousActivated') }}
-                <span class="font-weight-bold">
-                  {{ memoryPreviousActivated }}
-                </span>
-              </p>
               <p>
                 {{ $t('pageCapacityOnDemand.orderInfo.memoryResourceId') }}
                 <span class="font-weight-bold">
@@ -119,12 +101,6 @@
                 {{ $t('pageCapacityOnDemand.orderInfo.memoryLicensed') }}
                 <span class="font-weight-bold">
                   {{ dataFormatter(memoryLicensed) }}
-                </span>
-              </p>
-              <p>
-                {{ $t('pageCapacityOnDemand.orderInfo.entryCheck') }}:
-                <span class="font-weight-bold">
-                  {{ memoryEntryCheck }}
                 </span>
               </p>
             </b-col>
@@ -189,26 +165,6 @@ export default {
       // This logic checks to see if there are any licences in the store.
       // If there are none, the result is true, otherwise false.
       return !Object.keys(this.$store.getters['licenses/licenses']).length;
-    },
-    memoryPreviousActivated() {
-      return this.licenses?.PermMem?.AuthDeviceNumber
-        ? this.licenses?.PermMem?.AuthDeviceNumber
-        : '0000';
-    },
-    processorPreviousActivated() {
-      return this.licenses?.PermProcs?.AuthDeviceNumber
-        ? this.licenses?.PermProcs?.AuthDeviceNumber
-        : '0000';
-    },
-    processorEntryCheck() {
-      return this.licenses?.PermProcs?.EntryCheck
-        ? this.licenses?.PermProcs?.EntryCheck
-        : 'XX';
-    },
-    memoryEntryCheck() {
-      return this.licenses?.PermMem?.EntryCheck
-        ? this.licenses?.PermMem?.EntryCheck
-        : 'XX';
     },
     processorLicensed() {
       return this.licenses?.PermProcs?.MaxAuthorizedDevices;


### PR DESCRIPTION
- Removed 'Previously Activated' and 'Entry Check' from Processor and Memory Information
- Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=731082