### PR TITLE
Added Info tooltip in Sensors

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -1578,6 +1578,7 @@
       "lowerWarning": "Lower warning",
       "name": "Name",
       "status": "Status",
+      "statusTooltip": "Status indicates the sensor status.  It does not reflect the hardware status of the inventory item.",
       "upperCritical": "Upper critical",
       "upperWarning": "Upper warning",
       "filter": {

--- a/src/views/HardwareStatus/Sensors/Sensors.vue
+++ b/src/views/HardwareStatus/Sensors/Sensors.vue
@@ -42,7 +42,6 @@
           sort-icon-left
           hover
           no-sort-reset
-          sticky-header="75vh"
           sort-by="status"
           show-empty
           :no-border-collapse="true"
@@ -78,6 +77,10 @@
             </b-form-checkbox>
           </template>
 
+          <template #head(status)="row">
+            {{ row.label }}
+            <info-tooltip :title="$t('pageSensors.table.statusTooltip')" />
+          </template>
           <template #cell(status)="{ value }">
             <status-icon :status="statusIcon(value)" /> {{ value }}
           </template>
@@ -129,6 +132,7 @@
 </template>
 
 <script>
+import InfoTooltip from '@/components/Global/InfoTooltip';
 import PageTitle from '@/components/Global/PageTitle';
 import Search from '@/components/Global/Search';
 import StatusIcon from '@/components/Global/StatusIcon';
@@ -156,6 +160,7 @@ import SearchFilterMixin, {
 export default {
   name: 'Sensors',
   components: {
+    InfoTooltip,
     PageTitle,
     Search,
     StatusIcon,


### PR DESCRIPTION
- Added an info tooltip for Status in Sensors page.
- Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=726791