### PR TITLE
Handled missing PCIeDevice

### DIFF
--- a/src/store/modules/HardwareStatus/FabricAdaptersStore.js
+++ b/src/store/modules/HardwareStatus/FabricAdaptersStore.js
@@ -52,8 +52,8 @@ const FabricAdaptersStore = {
               if (memberResponse.data?.Links?.PCIeDevices.length > 0) {
                 res.data.Slots.map((singleSlot) => {
                   if (
-                    singleSlot.Links?.PCIeDevice[0]['@odata.id'] ===
-                    memberResponse.data?.Links?.PCIeDevices[0]['@odata.id']
+                    singleSlot.Links?.PCIeDevice?.[0]?.['@odata.id'] ===
+                    memberResponse.data?.Links?.PCIeDevices?.[0]?.['@odata.id']
                   ) {
                     tempFabricAdapters.push(memberResponse.data);
                     commit('setFabricAdaptersInfo', tempFabricAdapters);


### PR DESCRIPTION
- Handled missing PCIeDevice in PCIeSlots and PCIeDevices in Fabric Adapters used to list the Fabric adapters.
- Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=739549