### PR TITLE
Added data-test-ids for Network page

### DIFF
--- a/src/views/Settings/Network/TableIpv4.vue
+++ b/src/views/Settings/Network/TableIpv4.vue
@@ -28,6 +28,7 @@
           <BButton
             variant="primary"
             :disabled="isTablesDisabled"
+            data-test-id="add-static-ipv4"
             @click="initIpv4Modal()"
           >
             <icon-add />
@@ -62,8 +63,14 @@
             @click-table-action="onIpv4TableAction(action, $event, item)"
           >
             <template #icon>
-              <icon-edit v-if="action.value === 'edit'" />
-              <icon-trashcan v-if="action.value === 'delete'" />
+              <icon-edit
+                v-if="action.value === 'edit'"
+                data-test-id="edit-static-ipv4"
+              />
+              <icon-trashcan
+                v-if="action.value === 'delete'"
+                data-test-id="delete-static-ipv4"
+              />
             </template>
           </table-row-action>
         </template>

--- a/src/views/Settings/Network/TableIpv6.vue
+++ b/src/views/Settings/Network/TableIpv6.vue
@@ -50,6 +50,7 @@
           <BButton
             variant="primary"
             :disabled="isTablesDisabled"
+            data-test-id="add-static-ipv6"
             @click="initIpv6Modal()"
           >
             <icon-add />
@@ -84,8 +85,14 @@
             @click-table-action="onIpv6TableAction(action, $event, item)"
           >
             <template #icon>
-              <icon-edit v-if="action.value === 'edit'" />
-              <icon-trashcan v-if="action.value === 'delete'" />
+              <icon-edit
+                v-if="action.value === 'edit'"
+                data-test-id="edit-static-ipv6"
+              />
+              <icon-trashcan
+                v-if="action.value === 'delete'"
+                data-test-id="delete-static-ipv6"
+              />
             </template>
           </table-row-action>
         </template>

--- a/src/views/Settings/Network/TableIpv6StaticDefaultGateway.vue
+++ b/src/views/Settings/Network/TableIpv6StaticDefaultGateway.vue
@@ -7,6 +7,7 @@
             <BButton
               variant="primary"
               :disabled="isTablesDisabled"
+              data-test-id="add-static-default-gateway"
               @click="initIpv6DefaultGatewayModal()"
             >
               <icon-add />
@@ -35,8 +36,14 @@
                 "
               >
                 <template #icon>
-                  <icon-edit v-if="action.value === 'edit'" />
-                  <icon-trashcan v-if="action.value === 'delete'" />
+                  <icon-edit
+                    v-if="action.value === 'edit'"
+                    data-test-id="edit-static-default-gateway"
+                  />
+                  <icon-trashcan
+                    v-if="action.value === 'delete'"
+                    data-test-id="delete-static-default-gateway"
+                  />
                 </template>
               </table-row-action>
             </template>


### PR DESCRIPTION
- Added data-test-ids for Add, Edit and Delete buttons for TableIpv4, TablIpv6 and TablIpv6StaticDefaultGateway.
- Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=760730