### PR TITLE
Fixed 404 Not found for “Continue to OS Running”

### DIFF
--- a/src/store/modules/Operations/BootSettingsStore.js
+++ b/src/store/modules/Operations/BootSettingsStore.js
@@ -235,7 +235,7 @@ export const BootSettingsStore = defineStore('bootSettings', {
     async standbyToRuntime() {
       // Action not tested. Remove this comment once the action is tested and verified.
       return await api
-        .post('redfish/v1/Systems/hypervisor/Actions/ComputerSystem.Reset', {
+        .post('/redfish/v1/Systems/hypervisor/Actions/ComputerSystem.Reset', {
           ResetType: 'On',
         })
         .then(() => {


### PR DESCRIPTION
- Fixed 404 Not found for “Continue to OS Running” in Server power ops.
- Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=761006