### PR TITLE
Fixed static ipv6 prefix length issue

### DIFF
--- a/src/views/Settings/Network/ModalIpv6.vue
+++ b/src/views/Settings/Network/ModalIpv6.vue
@@ -58,7 +58,7 @@
               >
                 {{
                   $t('global.form.valueMustBeBetween', {
-                    min: 0,
+                    min: 1,
                     max: 128,
                   })
                 }}
@@ -117,7 +117,7 @@ const rules = computed(() => ({
     },
     prefixLength: {
       required,
-      minValue: minValue(0),
+      minValue: minValue(1),
       maxValue: maxValue(128),
     },
   },


### PR DESCRIPTION
- Fixed an issue where the user was able to add static ipv6 with prefix length as 0 or change the prefix length to 0 while editing
- Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=766521