### PR TITLE
Added data-test-ids for Dumps

### DIFF
--- a/src/views/Logs/Dumps/DumpsForm.vue
+++ b/src/views/Logs/Dumps/DumpsForm.vue
@@ -14,6 +14,7 @@
           v-model="selectedDumpType"
           :options="updatedDumpTypeOptions"
           :state="getValidationState(v$.selectedDumpType)"
+          data-test-id="dumps-form-dump-type-select"
           @change="updateDumpInfo"
         >
           <template #first>
@@ -35,7 +36,11 @@
             />
           </template>
 
-          <BForm-input id="resourceSelector" v-model="resourceSelectorValue">
+          <BForm-input
+            id="resourceSelector"
+            v-model="resourceSelectorValue"
+            data-test-id="dumps-form-resource-selector-input"
+          >
           </BForm-input>
         </BFormGroup>
         <template v-if="isServiceUser">
@@ -50,6 +55,7 @@
                 v-model="resourcePasswordValue"
                 autocomplete="off"
                 :type="inputType"
+                data-test-id="dumps-form-resource-password-input"
               >
               </BForm-input>
             </input-password-toggle>
@@ -61,6 +67,7 @@
         variant="primary"
         type="submit"
         form="form-new-dump"
+        data-test-id="dumps-form-initiate-dump-button"
       >
         {{ $t('pageDumps.form.initiateDump') }}
       </b-button>

--- a/src/views/Logs/Dumps/DumpsModalConfirmation.vue
+++ b/src/views/Logs/Dumps/DumpsModalConfirmation.vue
@@ -4,6 +4,7 @@
     ref="modal"
     v-model="modal"
     :title="$t('pageDumps.modal.initiateSystemDump')"
+    data-test-id="dumps-modal-system-dump-confirmation"
     @show="resetForm"
   >
     <p>
@@ -20,6 +21,7 @@
     </p>
     <BFormCheckbox
       v-model="confirmed"
+      data-test-id="dumps-modal-confirmation-checkbox"
       @update:model-value="v$.confirmed.$touch()"
     >
       {{ $t('pageDumps.modal.initiateSystemDumpMessage4') }}
@@ -31,10 +33,18 @@
       {{ $t('global.form.required') }}
     </BFormInvalidFeedback>
     <template #footer="{ cancel }">
-      <BButton variant="secondary" @click="cancel()">
+      <BButton
+        variant="secondary"
+        data-test-id="dumps-modal-cancel-button"
+        @click="cancel()"
+      >
         {{ $t('global.action.cancel') }}
       </BButton>
-      <BButton variant="danger" @click="handleSubmit()">
+      <BButton
+        variant="danger"
+        data-test-id="dumps-modal-initiate-button"
+        @click="handleSubmit()"
+      >
         {{ $t('pageDumps.form.initiateDump') }}
       </BButton>
     </template>


### PR DESCRIPTION
- Added data-test-ids for helping test automation in Dumps page.
- Feature: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=778631