### PR TITLE
Added data-test-ids for Hw Deconfig, Deconfig rec

### DIFF
--- a/src/views/Logs/DeconfigurationRecords/DeconfigurationRecords.vue
+++ b/src/views/Logs/DeconfigurationRecords/DeconfigurationRecords.vue
@@ -16,10 +16,15 @@
     </alert>
     <BRow>
       <BCol class="text-right">
-        <table-filter :filters="tableFilters" @filter-change="onFilterChange" />
+        <table-filter
+          :filters="tableFilters"
+          data-test-id="deconfigRecords-filter"
+          @filter-change="onFilterChange"
+        />
         <BButton
           variant="link"
           :disabled="allEntries.length === 0 || !isServerOff()"
+          data-test-id="deconfigRecords-button-clearAll"
           @click="clearAllEntries"
         >
           <icon-delete /> {{ $t('global.action.clearAll') }}
@@ -29,6 +34,7 @@
           :class="{ disabled: allEntries.length === 0 }"
           :download="exportFileNameByDate()"
           :href="href"
+          data-test-id="deconfigRecords-button-exportAll"
         >
           <icon-export /> {{ $t('global.action.exportAll') }}
         </BButton>
@@ -240,6 +246,7 @@
             id="pagination-items-per-page"
             v-model="itemPerPage"
             :options="itemsPerPageOptions"
+            data-test-id="deconfigRecords-itemsPerPage"
           />
         </BFormGroup>
       </BCol>

--- a/src/views/Settings/HardwareDeconfiguration/HardwareDeconfiguration.vue
+++ b/src/views/Settings/HardwareDeconfiguration/HardwareDeconfiguration.vue
@@ -30,10 +30,16 @@
         <BCol>
           <b-card no-body>
             <b-tabs content-class="mt-3" fill>
-              <b-tab :title="$t('pageDeconfigurationHardware.memoryDimms')">
+              <b-tab
+                :title="$t('pageDeconfigurationHardware.memoryDimms')"
+                data-test-id="hardwareDeconfig-tab-memoryDimms"
+              >
                 <memory-dimms />
               </b-tab>
-              <b-tab :title="$t('pageDeconfigurationHardware.processorCores')">
+              <b-tab
+                :title="$t('pageDeconfigurationHardware.processorCores')"
+                data-test-id="hardwareDeconfig-tab-processorCores"
+              >
                 <processor-cores />
               </b-tab>
             </b-tabs>

--- a/src/views/Settings/HardwareDeconfiguration/MemoryDimms.vue
+++ b/src/views/Settings/HardwareDeconfiguration/MemoryDimms.vue
@@ -2,7 +2,11 @@
   <BContainer fluid="xl">
     <BRow class="align-items-end">
       <BCol sm="12" class="text-right">
-        <table-filter :filters="tableFilters" @filter-change="onFilterChange" />
+        <table-filter
+          :filters="tableFilters"
+          data-test-id="hardwareDeconfig-memoryDimms-filter"
+          @filter-change="onFilterChange"
+        />
       </BCol>
     </BRow>
     <BRow>
@@ -74,6 +78,7 @@
             id="pagination-items-per-page"
             v-model="itemPerPage"
             :options="itemsPerPageOptions"
+            data-test-id="hardwareDeconfig-memoryDimms-itemsPerPage"
           />
         </b-form-group>
       </BCol>

--- a/src/views/Settings/HardwareDeconfiguration/ProcessorCores.vue
+++ b/src/views/Settings/HardwareDeconfiguration/ProcessorCores.vue
@@ -2,7 +2,11 @@
   <BContainer fluid="xl">
     <BRow class="align-items-end">
       <BCol sm="12" class="text-right">
-        <table-filter :filters="tableFilters" @filter-change="onFilterChange" />
+        <table-filter
+          :filters="tableFilters"
+          data-test-id="hardwareDeconfig-processorCores-filter"
+          @filter-change="onFilterChange"
+        />
       </BCol>
     </BRow>
     <BRow>
@@ -88,6 +92,7 @@
             id="pagination-item-per-page"
             v-model="itemPerPage"
             :options="itemsPerPageOptions"
+            data-test-id="hardwareDeconfig-processorCores-itemsPerPage"
           />
         </BFormGroup>
       </BCol>


### PR DESCRIPTION
- Added data-test-ids for Hw Deconfig and Deconfig records.
- Feature: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=778631