### PR TITLE
Upgrade lodash to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "date-fns-tz": "3.1.3",
         "js-cookie": "^3.0.5",
         "json-bigint": "1.0.0",
-        "lodash": "4.17.21",
+        "lodash": "4.18.1",
         "n64": "0.2.10",
         "pinia": "2.1.7",
         "qrcode.vue": "3.6.0",
@@ -5475,9 +5475,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "date-fns-tz": "3.1.3",
     "js-cookie": "^3.0.5",
     "json-bigint": "1.0.0",
-    "lodash": "4.17.21",
+    "lodash": "4.18.1",
     "n64": "0.2.10",
     "pinia": "2.1.7",
     "qrcode.vue": "3.6.0",


### PR DESCRIPTION
- Upgrade loash to latest because of Vulnerability.
- Vulnerability: https://github.com/lodash/lodash/security/advisories/GHSA-xxjr-mmjv-4gpg