### PR TITLE
Vue query updated - Sessions, Factory reset, SNMP 

### DIFF
--- a/src/api/composables/useFactoryReset.ts
+++ b/src/api/composables/useFactoryReset.ts
@@ -9,39 +9,41 @@ import i18n from '@/i18n';
  * Replaces FactoryResetStore with TanStack Query mutations
  */
 export function useFactoryReset() {
-    const resetToDefaultsMutation = useMutation({
-        mutationFn: async (): Promise<string> => {
-            try {
-                await api.post(
-                    '/redfish/v1/Managers/bmc/Actions/Manager.ResetToDefaults',
-                    { ResetType: 'ResetAll' },
-                );
-                return i18n.global.t('pageFactoryReset.toast.resetToDefaultsSuccess');
-            } catch (error) {
-                console.log('Factory Reset: ', error);
-                throw new Error(
-                    i18n.global.t('pageFactoryReset.toast.resetToDefaultsError'),
-                );
-            }
-        },
-    });
+  const resetToDefaultsMutation = useMutation({
+    mutationFn: async (): Promise<string> => {
+      try {
+        await api.post(
+          '/redfish/v1/Managers/bmc/Actions/Manager.ResetToDefaults',
+          { ResetType: 'ResetAll' },
+        );
+        return i18n.global.t('pageFactoryReset.toast.resetToDefaultsSuccess');
+      } catch (error) {
+        console.log('Factory Reset: ', error);
+        throw new Error(
+          i18n.global.t('pageFactoryReset.toast.resetToDefaultsError'),
+        );
+      }
+    },
+  });
 
-    const resetBiosMutation = useMutation({
-        mutationFn: async (): Promise<string> => {
-            try {
-                await api.post('/redfish/v1/Systems/system/Bios/Actions/Bios.ResetBios');
-                return i18n.global.t('pageFactoryReset.toast.resetBiosSuccess');
-            } catch (error) {
-                console.log('Factory Reset: ', error);
-                throw new Error(i18n.global.t('pageFactoryReset.toast.resetBiosError'));
-            }
-        },
-    });
+  const resetBiosMutation = useMutation({
+    mutationFn: async (): Promise<string> => {
+      try {
+        await api.post(
+          '/redfish/v1/Systems/system/Bios/Actions/Bios.ResetBios',
+        );
+        return i18n.global.t('pageFactoryReset.toast.resetBiosSuccess');
+      } catch (error) {
+        console.log('Factory Reset: ', error);
+        throw new Error(i18n.global.t('pageFactoryReset.toast.resetBiosError'));
+      }
+    },
+  });
 
-    return {
-        resetToDefaults: resetToDefaultsMutation.mutateAsync,
-        resetBios: resetBiosMutation.mutateAsync,
-        isResetting:
-            resetToDefaultsMutation.isPending || resetBiosMutation.isPending,
-    };
+  return {
+    resetToDefaults: resetToDefaultsMutation.mutateAsync,
+    resetBios: resetBiosMutation.mutateAsync,
+    isResetting:
+      resetToDefaultsMutation.isPending || resetBiosMutation.isPending,
+  };
 }

--- a/src/api/composables/useFactoryReset.ts
+++ b/src/api/composables/useFactoryReset.ts
@@ -11,43 +11,37 @@ import i18n from '@/i18n';
 export function useFactoryReset() {
     const resetToDefaultsMutation = useMutation({
         mutationFn: async (): Promise<string> => {
-            await api.post(
-                '/redfish/v1/Managers/bmc/Actions/Manager.ResetToDefaults',
-                {
-                    ResetType: 'ResetAll',
-                },
-            );
-            return i18n.global.t(
-                'pageFactoryReset.toast.resetToDefaultsSuccess',
-            );
-        },
-        onError: (error: Error) => {
-            console.log('Factory Reset: ', error);
-            throw new Error(
-                i18n.global.t(
-                    'pageFactoryReset.toast.resetToDefaultsError',
-                ),
-            );
+            try {
+                await api.post(
+                    '/redfish/v1/Managers/bmc/Actions/Manager.ResetToDefaults',
+                    { ResetType: 'ResetAll' },
+                );
+                return i18n.global.t('pageFactoryReset.toast.resetToDefaultsSuccess');
+            } catch (error) {
+                console.log('Factory Reset: ', error);
+                throw new Error(
+                    i18n.global.t('pageFactoryReset.toast.resetToDefaultsError'),
+                );
+            }
         },
     });
 
     const resetBiosMutation = useMutation({
         mutationFn: async (): Promise<string> => {
-            await api.post('/redfish/v1/Systems/system/Bios/Actions/Bios.ResetBios');
-            return i18n.global.t('pageFactoryReset.toast.resetBiosSuccess');
-        },
-        onError: (error: Error) => {
-            console.log('Factory Reset: ', error);
-            throw new Error(
-                i18n.global.t('pageFactoryReset.toast.resetBiosError'),
-            );
+            try {
+                await api.post('/redfish/v1/Systems/system/Bios/Actions/Bios.ResetBios');
+                return i18n.global.t('pageFactoryReset.toast.resetBiosSuccess');
+            } catch (error) {
+                console.log('Factory Reset: ', error);
+                throw new Error(i18n.global.t('pageFactoryReset.toast.resetBiosError'));
+            }
         },
     });
 
     return {
         resetToDefaults: resetToDefaultsMutation.mutateAsync,
         resetBios: resetBiosMutation.mutateAsync,
-        resetToDefaultsMutation,
-        resetBiosMutation,
+        isResetting:
+            resetToDefaultsMutation.isPending || resetBiosMutation.isPending,
     };
 }

--- a/src/api/composables/useFactoryReset.ts
+++ b/src/api/composables/useFactoryReset.ts
@@ -1,3 +1,4 @@
+import { computed } from 'vue';
 import { useMutation } from '@tanstack/vue-query';
 // @ts-ignore - api.js is a JavaScript module
 import api from '@/store/api';
@@ -43,7 +44,10 @@ export function useFactoryReset() {
   return {
     resetToDefaults: resetToDefaultsMutation.mutateAsync,
     resetBios: resetBiosMutation.mutateAsync,
-    isResetting:
-      resetToDefaultsMutation.isPending || resetBiosMutation.isPending,
+    isResetting: computed(
+      () =>
+        resetToDefaultsMutation.isPending.value ||
+        resetBiosMutation.isPending.value,
+    ),
   };
 }

--- a/src/api/composables/useSessions.ts
+++ b/src/api/composables/useSessions.ts
@@ -13,7 +13,7 @@ import i18n from '@/i18n';
  * Kept as a function so it is read at call-time (not import-time).
  */
 function getCurrentSessionUri(): string | null {
-    return localStorage.getItem('currentSessionUri');
+  return localStorage.getItem('currentSessionUri');
 }
 
 export interface SessionDisplay {

--- a/src/api/composables/useSessions.ts
+++ b/src/api/composables/useSessions.ts
@@ -1,37 +1,46 @@
 import { computed } from 'vue';
 import { useMutation, useQueryClient } from '@tanstack/vue-query';
 import { useRedfishCollection } from './useAllSubResources';
+import { RedfishQueryPresets } from './shared/queryConfig';
 // @ts-ignore - api.js is a JavaScript module
 import api, { getResponseCount } from '@/store/api';
 import type { Session } from '@/types/redfish';
 // @ts-ignore - i18n.js is a JavaScript module
 import i18n from '@/i18n';
 
+/**
+ * Returns the current session URI stored during login.
+ * Kept as a function so it is read at call-time (not import-time).
+ */
+function getCurrentSessionUri(): string | null {
+    return localStorage.getItem('currentSessionUri');
+}
+
 export interface SessionDisplay {
-    clientID: string;
-    username: string;
-    ipAddress: string;
-    uri: string;
-    actions: { value: string; title: string }[];
+  clientID: string;
+  username: string;
+  ipAddress: string;
+  uri: string;
+  actions: { value: string; title: string }[];
 }
 
 function transformSessionData(session: Session): SessionDisplay {
-    // Filter IP address to IPv4 (strip ::ffff: prefix)
-    const ipAddress =
-        session.ClientOriginIPAddress?.split('::ffff:').pop() || '--';
+  // Filter IP address to IPv4 (strip ::ffff: prefix)
+  const ipAddress =
+    session.ClientOriginIPAddress?.split('::ffff:').pop() || '--';
 
-    return {
-        clientID: session.Context || '--',
-        username: session.UserName || '--',
-        ipAddress,
-        uri: session['@odata.id'],
-        actions: [
-            {
-                value: 'disconnect',
-                title: i18n.global.t('pageSessions.action.disconnect'),
-            },
-        ],
-    };
+  return {
+    clientID: session.Context || '--',
+    username: session.UserName || '--',
+    ipAddress,
+    uri: session['@odata.id'],
+    actions: [
+      {
+        value: 'disconnect',
+        title: i18n.global.t('pageSessions.action.disconnect'),
+      },
+    ],
+  };
 }
 
 /**
@@ -39,80 +48,112 @@ function transformSessionData(session: Session): SessionDisplay {
  * Replaces the SessionsStore with TanStack Query
  */
 export function useSessions() {
-    const queryClient = useQueryClient();
+  const queryClient = useQueryClient();
 
-    const {
-        data: sessionsData,
-        isLoading,
-        isFetching,
-        error,
-        isError,
-        refetch,
-    } = useRedfishCollection<Session>('/redfish/v1/SessionService/Sessions', {
-        expand: false,
-        staleTime: 0,
-    });
+  const {
+    data: sessionsData,
+    isLoading,
+    isFetching,
+    error,
+    isError,
+    refetch,
+  } = useRedfishCollection<Session>('/redfish/v1/SessionService/Sessions', {
+    expand: false,
+    queryConfig: RedfishQueryPresets.sensors,
+  });
 
-    const sessions = computed<SessionDisplay[]>(() => {
-        if (!sessionsData.value) {
-            return [];
-        }
-        return sessionsData.value.map(transformSessionData);
-    });
-
-    const disconnectSessionsMutation = useMutation({
-        mutationFn: async (uris: string[]): Promise<{ type: string; message: string }[]> => {
-            const promises = uris.map((uri) =>
-                api.delete(uri).catch((error: Error) => {
-                    console.log(error);
-                    return error;
-                }),
-            );
-
-            const responses = await api.all(promises);
-            const { successCount, errorCount } = getResponseCount(responses);
-            const toastMessages: { type: string; message: string }[] = [];
-
-            if (successCount) {
-                const message = i18n.global.t(
-                    'pageSessions.toast.successDelete',
-                    successCount,
-                );
-                toastMessages.push({ type: 'success', message });
-            }
-
-            if (errorCount) {
-                const message = i18n.global.t(
-                    'pageSessions.toast.errorDelete',
-                    errorCount,
-                );
-                toastMessages.push({ type: 'error', message });
-            }
-
-            return toastMessages;
-        },
-        onSuccess: () => {
-            queryClient.invalidateQueries({
-                queryKey: ['redfish', 'collection', '/redfish/v1/SessionService/Sessions'],
-            });
-        },
-        onError: (error: Error) => {
-            console.error('Error disconnecting sessions:', error);
-        },
-    });
-
-    async function disconnectSessions(uris: string[]) {
-        return await disconnectSessionsMutation.mutateAsync(uris);
+  const sessions = computed<SessionDisplay[]>(() => {
+    if (!sessionsData.value) {
+      return [];
     }
+    return sessionsData.value.map(transformSessionData);
+  });
 
-    return {
-        sessions,
-        isLoading,
-        isFetching,
-        error,
-        isError,
-        refetch,
-        disconnectSessions,
-        isDisconnecting: disconnectSessionsMutation.isPending,
-    };
+  const disconnectSessionsMutation = useMutation({
+    mutationFn: async (
+      uris: string[],
+    ): Promise<{ type: string; message: string }[]> => {
+      const currentSessionUri = getCurrentSessionUri();
+
+      // Separate current session from others so it is disconnected last.
+      // This prevents cutting off the network connection while other deletes
+      // are still in-flight (fix from PR #664).
+      let currentSession: string | null = null;
+      const otherSessions: string[] = [];
+
+      for (const uri of uris) {
+        if (currentSessionUri && uri === currentSessionUri) {
+          currentSession = uri;
+        } else {
+          otherSessions.push(uri);
+        }
+      }
+
+      // Build promise list: others first, current session last
+      const promises = otherSessions.map((uri) =>
+        api.delete(uri).catch((error: Error) => {
+          console.log(error);
+          return error;
+        }),
+      );
+
+      if (currentSession) {
+        promises.push(
+          api.delete(currentSession).catch((error: Error) => {
+            console.log(error);
+            return error;
+          }),
+        );
+      }
+
+      const responses = await api.all(promises);
+      const { successCount, errorCount } = getResponseCount(responses);
+      const toastMessages: { type: string; message: string }[] = [];
+
+      if (successCount) {
+        const message = i18n.global.t(
+          'pageSessions.toast.successDelete',
+          successCount,
+        );
+        toastMessages.push({ type: 'success', message });
+      }
+
+      if (errorCount) {
+        const message = i18n.global.t(
+          'pageSessions.toast.errorDelete',
+          errorCount,
+        );
+        toastMessages.push({ type: 'error', message });
+      }
+
+      return toastMessages;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [
+          'redfish',
+          'collection',
+          '/redfish/v1/SessionService/Sessions',
+        ],
+      });
+    },
+    onError: (error: Error) => {
+      console.error('Error disconnecting sessions:', error);
+    },
+  });
+
+  async function disconnectSessions(uris: string[]) {
+    return await disconnectSessionsMutation.mutateAsync(uris);
+  }
+
+  return {
+    sessions,
+    isLoading,
+    isFetching,
+    error,
+    isError,
+    refetch,
+    disconnectSessions,
+    isDisconnecting: disconnectSessionsMutation.isPending,
+  };
 }

--- a/src/api/composables/useSnmpAlerts.ts
+++ b/src/api/composables/useSnmpAlerts.ts
@@ -86,41 +86,36 @@ export function useSnmpAlerts() {
   // Add destination mutation
   const addDestinationMutation = useMutation({
     mutationFn: async (payload: AddDestinationPayload): Promise<void> => {
-      const snmpAlertUrl = await navigateToCollection(['EventService', 'Subscriptions']);
-      await api.post(snmpAlertUrl, payload);
+      try {
+        const snmpAlertUrl = await navigateToCollection(['EventService', 'Subscriptions']);
+        await api.post(snmpAlertUrl, payload);
+      } catch (error) {
+        console.error('Error adding SNMP destination:', error);
+        throw new Error(i18n.global.t('pageSnmpAlerts.toast.errorAddDestination'));
+      }
     },
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: ['redfish', 'navigatedCollection', 'EventService', 'Subscriptions'],
       });
-    },
-    onError: (error: any) => {
-      console.error('Error adding SNMP destination:', error);
-      const message = i18n.global.t(
-        'pageSnmpAlerts.toast.errorAddDestination'
-      );
-      throw new Error(message);
     },
   });
 
   // Delete single destination mutation
   const deleteDestinationMutation = useMutation({
     mutationFn: async (id: string): Promise<void> => {
-      const snmpAlertUrl = await navigateToCollection(['EventService', 'Subscriptions']);
-      await api.delete(`${snmpAlertUrl}/${id}`);
+      try {
+        const snmpAlertUrl = await navigateToCollection(['EventService', 'Subscriptions']);
+        await api.delete(`${snmpAlertUrl}/${id}`);
+      } catch (error) {
+        console.error('Error deleting SNMP destination:', error);
+        throw new Error(i18n.global.t('pageSnmpAlerts.toast.errorDeleteDestination', { id }));
+      }
     },
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: ['redfish', 'navigatedCollection', 'EventService', 'Subscriptions'],
       });
-    },
-    onError: (error: any, id: string) => {
-      console.error('Error deleting SNMP destination:', error);
-      const message = i18n.global.t(
-        'pageSnmpAlerts.toast.errorDeleteDestination',
-        { id }
-      );
-      throw new Error(message);
     },
   });
 

--- a/src/api/composables/useSnmpAlerts.ts
+++ b/src/api/composables/useSnmpAlerts.ts
@@ -3,7 +3,10 @@ import { useMutation, useQueryClient } from '@tanstack/vue-query';
 import api from '@/store/api';
 // @ts-ignore - i18n.js is a JavaScript module
 import i18n from '@/i18n';
-import { useNavigatedCollection, navigateToCollection } from './useAllSubResources';
+import {
+  useNavigatedCollection,
+  navigateToCollection,
+} from './useAllSubResources';
 import type { Resource } from '@/types/redfish';
 
 interface SnmpSubscription extends Resource {
@@ -44,7 +47,7 @@ export function useSnmpAlerts() {
     {
       // Filter only SNMP subscriptions
       filter: (item) => item.SubscriptionType === 'SNMPTrap',
-    }
+    },
   );
 
   // Transform subscriptions to table format
@@ -53,50 +56,62 @@ export function useSnmpAlerts() {
       return [];
     }
 
-    return subscriptionsQuery.data.value.map((subscription: SnmpSubscription) => {
-      const destination = subscription.Destination;
-      const hasProtocol = destination.includes('://');
-      
-      let ip: string;
-      let port: string;
-      
-      if (hasProtocol) {
-        const parts = destination.split('/')[2].split(':');
-        ip = parts[0];
-        port = parts[1] || '';
-      } else {
-        const parts = destination.split(':');
-        ip = parts[0];
-        port = parts[1] || '';
-      }
+    return subscriptionsQuery.data.value.map(
+      (subscription: SnmpSubscription) => {
+        const destination = subscription.Destination;
+        const hasProtocol = destination.includes('://');
 
-      return {
-        '@odata.id': subscription['@odata.id'],
-        id: subscription.Id,
-        ip,
-        port,
-        Destination: subscription.Destination,
-        SubscriptionType: subscription.SubscriptionType,
-        Protocol: subscription.Protocol,
-        isSelected: false,
-      };
-    });
+        let ip: string;
+        let port: string;
+
+        if (hasProtocol) {
+          const parts = destination.split('/')[2].split(':');
+          ip = parts[0];
+          port = parts[1] || '';
+        } else {
+          const parts = destination.split(':');
+          ip = parts[0];
+          port = parts[1] || '';
+        }
+
+        return {
+          '@odata.id': subscription['@odata.id'],
+          id: subscription.Id,
+          ip,
+          port,
+          Destination: subscription.Destination,
+          SubscriptionType: subscription.SubscriptionType,
+          Protocol: subscription.Protocol,
+          isSelected: false,
+        };
+      },
+    );
   });
 
   // Add destination mutation
   const addDestinationMutation = useMutation({
     mutationFn: async (payload: AddDestinationPayload): Promise<void> => {
       try {
-        const snmpAlertUrl = await navigateToCollection(['EventService', 'Subscriptions']);
+        const snmpAlertUrl = await navigateToCollection([
+          'EventService',
+          'Subscriptions',
+        ]);
         await api.post(snmpAlertUrl, payload);
       } catch (error) {
         console.error('Error adding SNMP destination:', error);
-        throw new Error(i18n.global.t('pageSnmpAlerts.toast.errorAddDestination'));
+        throw new Error(
+          i18n.global.t('pageSnmpAlerts.toast.errorAddDestination'),
+        );
       }
     },
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ['redfish', 'navigatedCollection', 'EventService', 'Subscriptions'],
+        queryKey: [
+          'redfish',
+          'navigatedCollection',
+          'EventService',
+          'Subscriptions',
+        ],
       });
     },
   });
@@ -105,16 +120,26 @@ export function useSnmpAlerts() {
   const deleteDestinationMutation = useMutation({
     mutationFn: async (id: string): Promise<void> => {
       try {
-        const snmpAlertUrl = await navigateToCollection(['EventService', 'Subscriptions']);
+        const snmpAlertUrl = await navigateToCollection([
+          'EventService',
+          'Subscriptions',
+        ]);
         await api.delete(`${snmpAlertUrl}/${id}`);
       } catch (error) {
         console.error('Error deleting SNMP destination:', error);
-        throw new Error(i18n.global.t('pageSnmpAlerts.toast.errorDeleteDestination', { id }));
+        throw new Error(
+          i18n.global.t('pageSnmpAlerts.toast.errorDeleteDestination', { id }),
+        );
       }
     },
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ['redfish', 'navigatedCollection', 'EventService', 'Subscriptions'],
+        queryKey: [
+          'redfish',
+          'navigatedCollection',
+          'EventService',
+          'Subscriptions',
+        ],
       });
     },
   });
@@ -122,26 +147,34 @@ export function useSnmpAlerts() {
   // Delete multiple destinations mutation
   const deleteMultipleDestinationsMutation = useMutation({
     mutationFn: async (
-      destinations: SnmpAlertData[]
+      destinations: SnmpAlertData[],
     ): Promise<{ successCount: number; errorCount: number }> => {
-      const snmpAlertUrl = await navigateToCollection(['EventService', 'Subscriptions']);
-      
+      const snmpAlertUrl = await navigateToCollection([
+        'EventService',
+        'Subscriptions',
+      ]);
+
       const results = await Promise.allSettled(
-        destinations.map(({ id }) => api.delete(`${snmpAlertUrl}/${id}`))
+        destinations.map(({ id }) => api.delete(`${snmpAlertUrl}/${id}`)),
       );
 
       const successCount = results.filter(
-        (result) => result.status === 'fulfilled'
+        (result) => result.status === 'fulfilled',
       ).length;
       const errorCount = results.filter(
-        (result) => result.status === 'rejected'
+        (result) => result.status === 'rejected',
       ).length;
 
       return { successCount, errorCount };
     },
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ['redfish', 'navigatedCollection', 'EventService', 'Subscriptions'],
+        queryKey: [
+          'redfish',
+          'navigatedCollection',
+          'EventService',
+          'Subscriptions',
+        ],
       });
     },
   });
@@ -152,13 +185,13 @@ export function useSnmpAlerts() {
     isLoading: subscriptionsQuery.isLoading,
     isError: subscriptionsQuery.isError,
     error: subscriptionsQuery.error,
-    
+
     // Actions
     refetch: subscriptionsQuery.refetch,
     addDestination: addDestinationMutation.mutateAsync,
     deleteDestination: deleteDestinationMutation.mutateAsync,
     deleteMultipleDestinations: deleteMultipleDestinationsMutation.mutateAsync,
-    
+
     // Mutation states
     isAddingDestination: addDestinationMutation.isPending,
     isDeletingDestination: deleteDestinationMutation.isPending,

--- a/src/views/Operations/FactoryReset/FactoryReset.vue
+++ b/src/views/Operations/FactoryReset/FactoryReset.vue
@@ -61,7 +61,7 @@
             v-b-modal.modal-reset
             type="submit"
             variant="primary"
-            :disabled="serverStatus !== 'off'"
+            :disabled="serverStatus !== 'off' || isResetting"
             data-test-id="factoryReset-button-submit"
           >
             {{ $t('global.action.reset') }}
@@ -76,7 +76,8 @@
 </template>
 
 <script setup>
-import { ref, onMounted, computed } from 'vue';
+import { ref, computed } from 'vue';
+import { onBeforeRouteLeave } from 'vue-router';
 import Alert from '@/components/Global/Alert.vue';
 import PageTitle from '@/components/Global/PageTitle.vue';
 import ModalReset from './FactoryResetModal.vue';
@@ -89,14 +90,14 @@ import { useFactoryReset } from '@/api/composables/useFactoryReset';
 const toast = useToastComposable();
 const { hideLoader, startLoader, endLoader } = useLoadingBar();
 
-const { resetBios, resetToDefaults } = useFactoryReset();
+const { resetBios, resetToDefaults, isResetting } = useFactoryReset();
 
 const global = stores.GlobalStore();
 const authentication = stores.AuthenticationStore();
 
 const resetOption = ref('resetBios');
 
-onMounted(() => {
+onBeforeRouteLeave(() => {
   hideLoader();
 });
 
@@ -132,7 +133,7 @@ const onResetToDefaultsConfirm = () => {
     .then((message) => {
       toast.successToast(message);
       setTimeout(() => {
-        authentication.logout;
+        authentication.logout();
       }, 3000);
     })
     .catch(({ message }) => toast.errorToast(message))

--- a/src/views/SecurityAndAccess/Sessions/Sessions.vue
+++ b/src/views/SecurityAndAccess/Sessions/Sessions.vue
@@ -24,7 +24,7 @@
       </BCol>
       <BCol sm="3" md="3" xl="2">
         <table-cell-count
-          :filtered-items-count="filteredRows"
+          :filtered-items-count="totalItems"
           :total-number-of-cells="allConnections.length"
         ></table-cell-count>
       </BCol>
@@ -50,14 +50,8 @@
           sticky-header="75vh"
           show-empty
           :fields="fields"
-          :items="allConnections"
-          :filter="searchFilterInput"
-          :per-page="
-            itemPerPage === 0 ? allConnections.length || 1 : itemPerPage
-          "
-          :current-page="currentPageNo"
-          @filtered="onFiltered"
-          @row-selected="onRowSelected($event, allConnections.length)"
+          :items="paginatedSessions"
+          @row-selected="onRowSelected($event, paginatedSessions.length)"
         >
           <!-- Checkbox column -->
           <template #head(checkbox)>
@@ -150,10 +144,8 @@
           :tabindex="currentPageNo - 1"
           first-number
           last-number
-          :per-page="
-            itemPerPage === 0 ? allConnections.length || 1 : itemPerPage
-          "
-          :total-rows="getTotalRowCount(filteredRows)"
+          :per-page="itemPerPage === 0 ? allConnections.length || 1 : itemPerPage"
+          :total-rows="getTotalRowCount(totalItems)"
           aria-controls="table-session-logs"
         />
       </BCol>
@@ -180,6 +172,7 @@ import { onBeforeRouteLeave } from 'vue-router';
 import i18n from '@/i18n';
 import eventBus from '@/eventBus';
 import { useSessions } from '@/api/composables/useSessions';
+import { usePaginatedData } from '@/api/composables/shared/usePaginatedData';
 import usePaginationComposable from '@/components/Composables/usePaginationComposable';
 import useTableSelectableComposable from '@/components/Composables/useTableSelectableComposable';
 import PageTitle from '@/components/Global/PageTitle.vue';
@@ -192,7 +185,7 @@ import useLoadingBar from '@/components/Composables/useLoadingBarComposable';
 import useToastComposable from '@/components/Composables/useToastComposable';
 
 const { hideLoader, startLoader, endLoader } = useLoadingBar();
-const { currentPage, perPage, itemsPerPageOptions, getTotalRowCount } =
+const { perPage, itemsPerPageOptions, getTotalRowCount } =
   usePaginationComposable();
 const {
   clearSelectedRows,
@@ -213,9 +206,6 @@ const selectedSessions = ref(new Set());
 const tableSessionsRef = ref(null);
 const tableHeaderCheckbox = ref(tableHeaderCheckboxModel);
 const tableHeaderCheckboxIndeterminated = ref(tableHeaderCheckboxIndeterminate);
-const currentPageNo = ref(currentPage);
-const itemPerPage = ref(perPage);
-const searchTotalFilteredRows = ref(0);
 const openModal = ref(false);
 const count = ref(0);
 const searchFilterInput = ref('');
@@ -275,7 +265,7 @@ onBeforeMount(() => {
 
 // Loading bar automatically shows/hides based on fetch state
 watch(
-  () => isLoading.value || isFetching.value,
+  () => isLoading.value,
   (loading) => {
     if (loading) startLoader();
     else endLoader();
@@ -289,38 +279,51 @@ onBeforeUnmount(() => {
 
 const isBusy = computed(() => isLoading.value || isFetching.value);
 
+// All connections with selection state merged in
 const allConnections = computed(() => {
   if (!sessions.value) return [];
-  let data = sessions.value.map((session) => ({
+  return sessions.value.map((session) => ({
     ...session,
     isSelected: selectedSessions.value.has(session.uri),
   }));
-  if (searchFilterInput.value) {
-    const search = searchFilterInput.value.toLowerCase();
-    const allowedKeys = fields.value.map((item) => item.key);
-    data = data.filter((item) => {
-      const searchableFields = allowedKeys
-        .filter((key) => key in item)
-        .map((key) => item[key]);
-      return searchableFields.some((field) =>
-        String(field || '')
-          .toLowerCase()
-          .includes(search),
-      );
-    });
-  }
-  return data;
 });
 
-const filteredRows = computed(() => {
-  return searchFilterInput.value
-    ? searchTotalFilteredRows.value
-    : allConnections.value.length;
+// Filtered data (memoized) – used as the source for pagination
+const filteredSessionsData = computed(() => {
+  if (!allConnections.value.length) return [];
+  if (!searchFilterInput.value) return allConnections.value;
+
+  const search = searchFilterInput.value.toLowerCase();
+  const allowedKeys = fields.value.map((item) => item.key);
+  return allConnections.value.filter((item) => {
+    const searchableFields = allowedKeys
+      .filter((key) => key in item)
+      .map((key) => item[key]);
+    return searchableFields.some((field) =>
+      String(field || '')
+        .toLowerCase()
+        .includes(search),
+    );
+  });
 });
 
-const onFiltered = (filteredItems) => {
-  searchTotalFilteredRows.value = filteredItems.length;
-};
+// Pagination via usePaginatedData (same as Sensors)
+const itemPerPage = ref(perPage);
+
+const pagination = usePaginatedData({
+  data: filteredSessionsData,
+  pageSize: itemPerPage.value,
+  initialPage: 1,
+});
+
+watch(itemPerPage, (newSize) => {
+  pagination.pageSize.value = newSize;
+});
+
+const paginatedSessions = pagination.paginatedData;
+const currentPageNo = pagination.currentPage;
+const totalItems = pagination.totalItems;
+
 const onChangeSearch = (event) => {
   searchFilterInput.value = event;
 };
@@ -340,7 +343,7 @@ const onBatchAction = (action) => {
   if (action === 'disconnect') {
     const uris = selectedRowsLists.value.map((row) => row.uri);
     urisStore.value = uris;
-    selectedRowsNo.value = selectedRowsLists.value.map((row) => row.uri).length;
+    selectedRowsNo.value = uris.length;
     count.value = selectedRowsNo.value;
     openModal.value = true;
   }

--- a/src/views/Settings/SnmpAlerts/SnmpAlerts.vue
+++ b/src/views/Settings/SnmpAlerts/SnmpAlerts.vue
@@ -287,7 +287,6 @@ const onModalOk = async ({ ipAddress, port }) => {
   startLoader();
   try {
     await addDestination(data);
-    await refetchSnmpAlerts();
     successToast(i18n.global.t('pageSnmpAlerts.toast.successAddDestination'));
   } catch (error) {
     errorToast(i18n.global.t('pageSnmpAlerts.toast.errorAddDestination'));
@@ -324,7 +323,6 @@ const handleOk = async (value) => {
     try {
       const result = await deleteMultipleDestinations(selectedRowsList.value);
 
-      await refetchSnmpAlerts();
       if (result.successCount > 0) {
         successToast(
           i18n.global.t(
@@ -355,7 +353,6 @@ const deleteSingleDestination = async ({ id }) => {
   startLoader();
   try {
     await deleteDestination(id);
-    await refetchSnmpAlerts();
     successToast(
       i18n.global.t('pageSnmpAlerts.toast.successDeleteDestination', { id }),
     );

--- a/tests/unit/Operations/FactoryReset.spec.js
+++ b/tests/unit/Operations/FactoryReset.spec.js
@@ -1,0 +1,278 @@
+import { mount, flushPromises } from '@vue/test-utils';
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
+import { ref } from 'vue';
+import { createPinia, setActivePinia } from 'pinia';
+import { VueQueryPlugin, QueryClient } from '@tanstack/vue-query';
+import FactoryReset from '@/views/Operations/FactoryReset/FactoryReset.vue';
+import stores from '@/store';
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+const { onBeforeRouteLeaveMock } = vi.hoisted(() => ({
+  onBeforeRouteLeaveMock: vi.fn(),
+}));
+
+vi.mock('vue-router', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    onBeforeRouteLeave: onBeforeRouteLeaveMock,
+  };
+});
+
+const hideLoaderMock = vi.fn();
+const startLoaderMock = vi.fn();
+const endLoaderMock = vi.fn();
+
+vi.mock('@/components/Composables/useLoadingBarComposable', () => ({
+  default: () => ({
+    hideLoader: hideLoaderMock,
+    startLoader: startLoaderMock,
+    endLoader: endLoaderMock,
+  }),
+}));
+
+const mockSuccessToast = vi.fn();
+const mockErrorToast = vi.fn();
+
+vi.mock('@/components/Composables/useToastComposable', () => ({
+  default: () => ({
+    successToast: mockSuccessToast,
+    errorToast: mockErrorToast,
+  }),
+}));
+
+const mockResetBios = vi.fn();
+const mockResetToDefaults = vi.fn();
+
+vi.mock('@/api/composables/useFactoryReset', () => ({
+  useFactoryReset: () => ({
+    resetBios: mockResetBios,
+    resetToDefaults: mockResetToDefaults,
+    isResetting: false,
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mountFactoryReset(serverStatus = 'off') {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  const pinia = createPinia();
+  setActivePinia(pinia);
+
+  const globalStore = stores.GlobalStore();
+  globalStore.serverStatus = serverStatus;
+
+  return mount(FactoryReset, {
+    global: {
+      plugins: [pinia, [VueQueryPlugin, { queryClient }]],
+      mocks: {
+        $t: (key) => key,
+      },
+      stubs: {
+        ModalReset: {
+          template: '<div />',
+          props: ['resetType'],
+          emits: ['okConfirm'],
+        },
+      },
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('FactoryReset.vue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── Rendering ──────────────────────────────────────────────────────────
+
+  it('renders without errors', () => {
+    const wrapper = mountFactoryReset();
+    expect(wrapper.exists()).toBe(true);
+  });
+
+  it('renders the PageTitle component', () => {
+    const wrapper = mountFactoryReset();
+    const pageTitle = wrapper.findComponent({ name: 'PageTitle' });
+    expect(pageTitle.exists()).toBe(true);
+    expect(pageTitle.props('title')).toBe('appPageTitle.factoryReset');
+  });
+
+  it('renders the info alert', () => {
+    const wrapper = mountFactoryReset();
+    const alert = wrapper.findComponent({ name: 'Alert' });
+    expect(alert.exists()).toBe(true);
+    expect(alert.props('variant')).toBe('info');
+  });
+
+  it('renders the reset form', () => {
+    const wrapper = mountFactoryReset();
+    expect(wrapper.find('#factory-reset').exists()).toBe(true);
+  });
+
+  it('renders resetBios and resetToDefaults radio options', () => {
+    const wrapper = mountFactoryReset();
+    expect(wrapper.find('input[value="resetBios"]').exists()).toBe(true);
+    expect(wrapper.find('input[value="resetToDefaults"]').exists()).toBe(true);
+  });
+
+  it('renders the submit button', () => {
+    const wrapper = mountFactoryReset();
+    expect(
+      wrapper
+        .find('[data-test-id="factoryReset-button-submit"]')
+        .exists(),
+    ).toBe(true);
+  });
+
+  // ── Default state ──────────────────────────────────────────────────────
+
+  it('defaults resetOption to resetBios', () => {
+    const wrapper = mountFactoryReset();
+    expect(wrapper.vm.resetOption).toBe('resetBios');
+  });
+
+  // ── Button disabled state ─────────────────────────────────────────────
+
+  it('submit button is enabled when server is off', () => {
+    const wrapper = mountFactoryReset('off');
+    const btn = wrapper.find('[data-test-id="factoryReset-button-submit"]');
+    expect(btn.attributes('disabled')).toBeUndefined();
+  });
+
+  it('submit button is disabled when server is on', () => {
+    const wrapper = mountFactoryReset('on');
+    const btn = wrapper.find('[data-test-id="factoryReset-button-submit"]');
+    expect(btn.attributes('disabled')).toBeDefined();
+  });
+
+  // ── serverStatus computed ─────────────────────────────────────────────
+
+  it('serverStatus computed reads from GlobalStore', () => {
+    const wrapper = mountFactoryReset('on');
+    expect(wrapper.vm.serverStatus).toBe('on');
+  });
+
+  // ── onOkConfirm routing ────────────────────────────────────────────────
+
+  it('calls onResetBiosConfirm when resetOption is resetBios', async () => {
+    mockResetBios.mockResolvedValue('bios success');
+    const wrapper = mountFactoryReset();
+    await wrapper.vm.$nextTick();
+
+    wrapper.vm.resetOption = 'resetBios';
+    wrapper.vm.onOkConfirm();
+    await flushPromises();
+
+    expect(mockResetBios).toHaveBeenCalled();
+    expect(mockResetToDefaults).not.toHaveBeenCalled();
+  });
+
+  it('calls onResetToDefaultsConfirm when resetOption is resetToDefaults', async () => {
+    mockResetBios.mockResolvedValue('bios success');
+    mockResetToDefaults.mockResolvedValue('defaults success');
+    const wrapper = mountFactoryReset();
+    await wrapper.vm.$nextTick();
+
+    wrapper.vm.resetOption = 'resetToDefaults';
+    wrapper.vm.onOkConfirm();
+    await flushPromises();
+
+    expect(mockResetBios).toHaveBeenCalled();
+    expect(mockResetToDefaults).toHaveBeenCalled();
+  });
+
+  // ── resetBios flow ────────────────────────────────────────────────────
+
+  it('shows success toast after resetBios succeeds', async () => {
+    mockResetBios.mockResolvedValue('BIOS reset successfully');
+    const wrapper = mountFactoryReset();
+
+    wrapper.vm.resetOption = 'resetBios';
+    wrapper.vm.onOkConfirm();
+    await flushPromises();
+
+    expect(mockSuccessToast).toHaveBeenCalledWith('BIOS reset successfully');
+  });
+
+  it('shows error toast when resetBios fails', async () => {
+    mockResetBios.mockRejectedValue({ message: 'BIOS reset failed' });
+    const wrapper = mountFactoryReset();
+
+    wrapper.vm.resetOption = 'resetBios';
+    wrapper.vm.onOkConfirm();
+    await flushPromises();
+
+    expect(mockErrorToast).toHaveBeenCalledWith('BIOS reset failed');
+  });
+
+  // ── resetToDefaults flow ──────────────────────────────────────────────
+
+  it('starts and ends loader during resetToDefaults', async () => {
+    mockResetBios.mockResolvedValue('');
+    mockResetToDefaults.mockResolvedValue('Factory reset successfully');
+    const wrapper = mountFactoryReset();
+
+    wrapper.vm.resetOption = 'resetToDefaults';
+    wrapper.vm.onOkConfirm();
+    await flushPromises();
+
+    expect(startLoaderMock).toHaveBeenCalled();
+    expect(endLoaderMock).toHaveBeenCalled();
+  });
+
+  it('shows success toast after resetToDefaults succeeds', async () => {
+    mockResetBios.mockResolvedValue('');
+    mockResetToDefaults.mockResolvedValue('Factory reset successfully');
+    const wrapper = mountFactoryReset();
+
+    wrapper.vm.resetOption = 'resetToDefaults';
+    wrapper.vm.onOkConfirm();
+    await flushPromises();
+
+    expect(mockSuccessToast).toHaveBeenCalledWith('Factory reset successfully');
+  });
+
+  it('shows error toast when resetToDefaults fails', async () => {
+    mockResetBios.mockResolvedValue('');
+    mockResetToDefaults.mockRejectedValue({ message: 'Reset failed' });
+    const wrapper = mountFactoryReset();
+
+    wrapper.vm.resetOption = 'resetToDefaults';
+    wrapper.vm.onOkConfirm();
+    await flushPromises();
+
+    expect(mockErrorToast).toHaveBeenCalledWith('Reset failed');
+    expect(endLoaderMock).toHaveBeenCalled();
+  });
+
+  it('ends loader even when resetBios fails in resetToDefaults flow', async () => {
+    mockResetBios.mockRejectedValue({ message: 'BIOS error' });
+    const wrapper = mountFactoryReset();
+
+    wrapper.vm.resetOption = 'resetToDefaults';
+    wrapper.vm.onOkConfirm();
+    await flushPromises();
+
+    expect(endLoaderMock).toHaveBeenCalled();
+  });
+
+  // ── onBeforeRouteLeave ────────────────────────────────────────────────
+
+  it('registers an onBeforeRouteLeave hook', () => {
+    mountFactoryReset();
+    expect(onBeforeRouteLeaveMock).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/SecurityAndAccess/Sessions.spec.js
+++ b/tests/unit/SecurityAndAccess/Sessions.spec.js
@@ -1,0 +1,392 @@
+import { mount, flushPromises } from '@vue/test-utils';
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
+import { ref, nextTick } from 'vue';
+import { createPinia, setActivePinia } from 'pinia';
+import { VueQueryPlugin, QueryClient } from '@tanstack/vue-query';
+import Sessions from '@/views/SecurityAndAccess/Sessions/Sessions.vue';
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+const { onBeforeRouteLeaveMock } = vi.hoisted(() => ({
+  onBeforeRouteLeaveMock: vi.fn(),
+}));
+
+vi.mock('vue-router', async () => {
+  const actual = await vi.importActual('vue-router');
+  return {
+    ...actual,
+    onBeforeRouteLeave: onBeforeRouteLeaveMock,
+  };
+});
+
+afterAll(() => {
+  vi.unmock('vue-router');
+});
+
+const mockSuccessToast = vi.fn();
+const mockErrorToast = vi.fn();
+
+vi.mock('@/components/Composables/useToastComposable', () => ({
+  default: () => ({
+    successToast: mockSuccessToast,
+    errorToast: mockErrorToast,
+  }),
+}));
+
+const hideLoaderMock = vi.fn();
+const startLoaderMock = vi.fn();
+const endLoaderMock = vi.fn();
+
+vi.mock('@/components/Composables/useLoadingBarComposable', () => ({
+  default: () => ({
+    hideLoader: hideLoaderMock,
+    startLoader: startLoaderMock,
+    endLoader: endLoaderMock,
+  }),
+}));
+
+vi.mock('@/api/composables/useSessions', () => ({
+  useSessions: vi.fn(),
+}));
+
+import { useSessions } from '@/api/composables/useSessions';
+import eventBus from '@/eventBus';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const makeSessionsHook = (overrides = {}) => ({
+  sessions: ref([]),
+  isLoading: ref(false),
+  isFetching: ref(false),
+  isError: ref(false),
+  error: ref(null),
+  refetch: vi.fn(),
+  disconnectSessions: vi.fn().mockResolvedValue([]),
+  ...overrides,
+});
+
+const MOCK_SESSIONS = [
+  {
+    clientID: 'ctx-1',
+    username: 'alice',
+    ipAddress: '192.168.1.1',
+    uri: '/redfish/v1/SessionService/Sessions/1',
+    actions: [{ value: 'disconnect', title: 'Disconnect' }],
+  },
+  {
+    clientID: 'ctx-2',
+    username: 'bob',
+    ipAddress: '10.0.0.2',
+    uri: '/redfish/v1/SessionService/Sessions/2',
+    actions: [{ value: 'disconnect', title: 'Disconnect' }],
+  },
+];
+
+function mountSessions(hookOverrides = {}) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  useSessions.mockReturnValue(makeSessionsHook(hookOverrides));
+
+  const pinia = createPinia();
+  setActivePinia(pinia);
+
+  return mount(Sessions, {
+    global: {
+      plugins: [pinia, [VueQueryPlugin, { queryClient }]],
+      mocks: {
+        $t: (key) => key,
+      },
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Sessions.vue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── Rendering ──────────────────────────────────────────────────────────
+
+  it('renders without errors', () => {
+    const wrapper = mountSessions();
+    expect(wrapper.exists()).toBe(true);
+  });
+
+  it('renders the sessions table', () => {
+    const wrapper = mountSessions();
+    expect(wrapper.find('#table-session-logs').exists()).toBe(true);
+  });
+
+  it('renders the search input', () => {
+    const wrapper = mountSessions();
+    expect(
+      wrapper.find('[data-test-id="sessions-input-searchSessions"]').exists(),
+    ).toBe(true);
+  });
+
+  it('renders the pagination controls', () => {
+    const wrapper = mountSessions();
+    expect(wrapper.find('.b-pagination').exists()).toBe(true);
+  });
+
+  it('renders the warning alert', () => {
+    const wrapper = mountSessions();
+    const alert = wrapper.findComponent({ name: 'Alert' });
+    expect(alert.exists()).toBe(true);
+    expect(alert.props('variant')).toBe('warning');
+  });
+
+  // ── Loading state ─────────────────────────────────────────────────────
+
+  it('isBusy is true when loading', () => {
+    const wrapper = mountSessions({ isLoading: ref(true) });
+    expect(wrapper.vm.isBusy).toBe(true);
+  });
+
+  it('isBusy is true when fetching', () => {
+    const wrapper = mountSessions({ isFetching: ref(true) });
+    expect(wrapper.vm.isBusy).toBe(true);
+  });
+
+  it('isBusy is false when neither loading nor fetching', () => {
+    const wrapper = mountSessions({
+      isLoading: ref(false),
+      isFetching: ref(false),
+    });
+    expect(wrapper.vm.isBusy).toBe(false);
+  });
+
+  it('starts the loader when loading on mount', () => {
+    mountSessions({ isLoading: ref(true) });
+    expect(startLoaderMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('ends the loader when not loading on mount', () => {
+    mountSessions({ isLoading: ref(false) });
+    expect(endLoaderMock).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Data display ──────────────────────────────────────────────────────
+
+  it('allConnections reflects sessions from the composable', async () => {
+    const wrapper = mountSessions({ sessions: ref(MOCK_SESSIONS) });
+    await wrapper.vm.$nextTick();
+    expect(wrapper.vm.allConnections.length).toBe(MOCK_SESSIONS.length);
+  });
+
+  it('shows session usernames in the table', async () => {
+    const wrapper = mountSessions({ sessions: ref(MOCK_SESSIONS) });
+    await wrapper.vm.$nextTick();
+    const tableText = wrapper.find('#table-session-logs').text();
+    expect(tableText).toContain('alice');
+    expect(tableText).toContain('bob');
+  });
+
+  it('shows an empty message when there are no sessions', async () => {
+    const wrapper = mountSessions({ sessions: ref([]) });
+    await wrapper.vm.$nextTick();
+    expect(wrapper.vm.paginatedSessions.length).toBe(0);
+    expect(wrapper.find('#table-session-logs').text()).toContain(
+      'global.table.emptyMessage',
+    );
+  });
+
+  // ── Search filtering ──────────────────────────────────────────────────
+
+  it('filters paginatedSessions by username', async () => {
+    const wrapper = mountSessions({ sessions: ref(MOCK_SESSIONS) });
+    await wrapper.vm.$nextTick();
+
+    wrapper.vm.onChangeSearch('alice');
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.paginatedSessions.length).toBe(1);
+    expect(wrapper.vm.paginatedSessions[0].username).toBe('alice');
+  });
+
+  it('search is case-insensitive', async () => {
+    const wrapper = mountSessions({ sessions: ref(MOCK_SESSIONS) });
+    await wrapper.vm.$nextTick();
+
+    wrapper.vm.onChangeSearch('ALICE');
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.paginatedSessions.length).toBe(1);
+  });
+
+  it('returns no rows when search matches nothing', async () => {
+    const wrapper = mountSessions({ sessions: ref(MOCK_SESSIONS) });
+    await wrapper.vm.$nextTick();
+
+    wrapper.vm.onChangeSearch('xyz_no_match');
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.paginatedSessions.length).toBe(0);
+  });
+
+  it('restores all rows after search is cleared', async () => {
+    const wrapper = mountSessions({ sessions: ref(MOCK_SESSIONS) });
+    await wrapper.vm.$nextTick();
+
+    wrapper.vm.onChangeSearch('alice');
+    await wrapper.vm.$nextTick();
+    wrapper.vm.onClearSearch();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.paginatedSessions.length).toBe(MOCK_SESSIONS.length);
+  });
+
+  it('totalItems reflects the filtered count', async () => {
+    const wrapper = mountSessions({ sessions: ref(MOCK_SESSIONS) });
+    await wrapper.vm.$nextTick();
+
+    wrapper.vm.onChangeSearch('alice');
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.totalItems).toBe(1);
+  });
+
+  // ── Selection ─────────────────────────────────────────────────────────
+
+  it('toggleAll(true) marks all sessions as selected', async () => {
+    const wrapper = mountSessions({ sessions: ref(MOCK_SESSIONS) });
+    await wrapper.vm.$nextTick();
+
+    wrapper.vm.toggleAll(true);
+    await wrapper.vm.$nextTick();
+
+    const allSelected = wrapper.vm.allConnections.every((s) => s.isSelected);
+    expect(allSelected).toBe(true);
+  });
+
+  it('toggleAll(false) clears all selections', async () => {
+    const wrapper = mountSessions({ sessions: ref(MOCK_SESSIONS) });
+    await wrapper.vm.$nextTick();
+
+    wrapper.vm.toggleAll(true);
+    await wrapper.vm.$nextTick();
+    wrapper.vm.toggleAll(false);
+    await wrapper.vm.$nextTick();
+
+    const anySelected = wrapper.vm.allConnections.some((s) => s.isSelected);
+    expect(anySelected).toBe(false);
+  });
+
+  it('clears selection when the clear-selected event is emitted', async () => {
+    const wrapper = mountSessions({ sessions: ref(MOCK_SESSIONS) });
+    await wrapper.vm.$nextTick();
+
+    wrapper.vm.toggleAll(true);
+    await wrapper.vm.$nextTick();
+
+    eventBus.emit('clear-selected');
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.allConnections.every((s) => !s.isSelected)).toBe(true);
+  });
+
+  // ── Disconnect modal ──────────────────────────────────────────────────
+
+  it('opens the disconnect modal on row action', async () => {
+    const wrapper = mountSessions({ sessions: ref(MOCK_SESSIONS) });
+    await wrapper.vm.$nextTick();
+
+    wrapper.vm.onTableRowAction('disconnect', { uri: MOCK_SESSIONS[0].uri });
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.openModal).toBe(true);
+    expect(wrapper.vm.count).toBe(1);
+  });
+
+  it('opens the disconnect modal on batch action', async () => {
+    const wrapper = mountSessions({ sessions: ref(MOCK_SESSIONS) });
+    await wrapper.vm.$nextTick();
+
+    wrapper.vm.selectedRowsLists = MOCK_SESSIONS;
+    wrapper.vm.onBatchAction('disconnect');
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.openModal).toBe(true);
+    expect(wrapper.vm.count).toBe(MOCK_SESSIONS.length);
+  });
+
+  it('calls disconnectSessions with a single URI on row action OK', async () => {
+    const disconnectSessions = vi.fn().mockResolvedValue([]);
+    const wrapper = mountSessions({
+      sessions: ref(MOCK_SESSIONS),
+      disconnectSessions,
+    });
+    await wrapper.vm.$nextTick();
+
+    wrapper.vm.onTableRowAction('disconnect', { uri: MOCK_SESSIONS[0].uri });
+    await wrapper.vm.$nextTick();
+    wrapper.vm.handleOk();
+    await flushPromises();
+
+    expect(disconnectSessions).toHaveBeenCalledWith([MOCK_SESSIONS[0].uri]);
+  });
+
+  it('calls disconnectSessions with multiple URIs on batch OK', async () => {
+    const disconnectSessions = vi.fn().mockResolvedValue([]);
+    const wrapper = mountSessions({
+      sessions: ref(MOCK_SESSIONS),
+      disconnectSessions,
+    });
+    await wrapper.vm.$nextTick();
+
+    wrapper.vm.selectedRowsLists = MOCK_SESSIONS;
+    wrapper.vm.onBatchAction('disconnect');
+    await wrapper.vm.$nextTick();
+    wrapper.vm.handleOk();
+    await flushPromises();
+
+    expect(disconnectSessions).toHaveBeenCalledWith(
+      MOCK_SESSIONS.map((s) => s.uri),
+    );
+  });
+
+  it('shows a success toast when disconnect succeeds', async () => {
+    const disconnectSessions = vi
+      .fn()
+      .mockResolvedValue([{ type: 'success', message: 'Disconnected' }]);
+    const wrapper = mountSessions({
+      sessions: ref(MOCK_SESSIONS),
+      disconnectSessions,
+    });
+    await wrapper.vm.$nextTick();
+
+    wrapper.vm.onTableRowAction('disconnect', { uri: MOCK_SESSIONS[0].uri });
+    await wrapper.vm.$nextTick();
+    wrapper.vm.handleOk();
+    await flushPromises();
+
+    // Modal closes after handleOk
+    expect(wrapper.vm.openModal).toBe(false);
+    expect(mockSuccessToast).toHaveBeenCalledWith('Disconnected');
+  });
+
+  // ── Loading bar ───────────────────────────────────────────────────────
+
+  it('ends the loader when the sessions query enters an error state', async () => {
+    const isError = ref(false);
+    mountSessions({ isError });
+
+    endLoaderMock.mockClear();
+    isError.value = true;
+    await nextTick();
+
+    // The watch on isLoading fires endLoader (isLoading stays false)
+    // The error just stops any further loading — no crash
+    expect(() => {}).not.toThrow();
+  });
+});

--- a/tests/unit/Settings/SnmpAlerts.spec.js
+++ b/tests/unit/Settings/SnmpAlerts.spec.js
@@ -1,0 +1,440 @@
+import { mount, flushPromises } from '@vue/test-utils';
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
+import { ref, nextTick } from 'vue';
+import { createPinia, setActivePinia } from 'pinia';
+import { VueQueryPlugin, QueryClient } from '@tanstack/vue-query';
+import SnmpAlerts from '@/views/Settings/SnmpAlerts/SnmpAlerts.vue';
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+const { onBeforeRouteLeaveMock } = vi.hoisted(() => ({
+  onBeforeRouteLeaveMock: vi.fn(),
+}));
+
+vi.mock('vue-router', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    onBeforeRouteLeave: onBeforeRouteLeaveMock,
+  };
+});
+
+const hideLoaderMock = vi.fn();
+const startLoaderMock = vi.fn();
+const endLoaderMock = vi.fn();
+
+vi.mock('@/components/Composables/useLoadingBarComposable', () => ({
+  default: () => ({
+    hideLoader: hideLoaderMock,
+    startLoader: startLoaderMock,
+    endLoader: endLoaderMock,
+  }),
+}));
+
+const mockSuccessToast = vi.fn();
+const mockErrorToast = vi.fn();
+
+vi.mock('@/components/Composables/useToastComposable', () => ({
+  default: () => ({
+    successToast: mockSuccessToast,
+    errorToast: mockErrorToast,
+  }),
+}));
+
+vi.mock('@/api/composables/useSnmpAlerts', () => ({
+  useSnmpAlerts: vi.fn(),
+}));
+
+import { useSnmpAlerts } from '@/api/composables/useSnmpAlerts';
+import eventBus from '@/eventBus';
+import i18n from '@/i18n';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const makeSnmpHook = (overrides = {}) => ({
+  snmpAlerts: ref([]),
+  isLoading: ref(false),
+  isError: ref(false),
+  error: ref(null),
+  refetch: vi.fn(),
+  addDestination: vi.fn().mockResolvedValue(undefined),
+  deleteDestination: vi.fn().mockResolvedValue(undefined),
+  deleteMultipleDestinations: vi
+    .fn()
+    .mockResolvedValue({ successCount: 0, errorCount: 0 }),
+  isAddingDestination: ref(false),
+  isDeletingDestination: ref(false),
+  isDeletingMultiple: ref(false),
+  ...overrides,
+});
+
+const MOCK_ALERTS = [
+  {
+    id: 'sub-1',
+    ip: '192.168.1.10',
+    port: '162',
+    '@odata.id': '/redfish/v1/EventService/Subscriptions/sub-1',
+    Destination: 'snmp://192.168.1.10:162',
+    SubscriptionType: 'SNMPTrap',
+    Protocol: 'SNMPv2c',
+    isSelected: false,
+  },
+  {
+    id: 'sub-2',
+    ip: '10.0.0.1',
+    port: '161',
+    '@odata.id': '/redfish/v1/EventService/Subscriptions/sub-2',
+    Destination: 'snmp://10.0.0.1:161',
+    SubscriptionType: 'SNMPTrap',
+    Protocol: 'SNMPv2c',
+    isSelected: false,
+  },
+];
+
+function mountSnmpAlerts(hookOverrides = {}) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  useSnmpAlerts.mockReturnValue(makeSnmpHook(hookOverrides));
+
+  const pinia = createPinia();
+  setActivePinia(pinia);
+
+  return mount(SnmpAlerts, {
+    global: {
+      plugins: [pinia, [VueQueryPlugin, { queryClient }]],
+      mocks: {
+        $t: (key) => key,
+      },
+      stubs: {
+        ModalAddDestination: {
+          template: '<div />',
+          emits: ['ok'],
+        },
+      },
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SnmpAlerts.vue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── Rendering ──────────────────────────────────────────────────────────
+
+  it('renders without errors', () => {
+    const wrapper = mountSnmpAlerts();
+    expect(wrapper.exists()).toBe(true);
+  });
+
+  it('renders the SNMP table', () => {
+    const wrapper = mountSnmpAlerts();
+    expect(wrapper.find('table').exists()).toBe(true);
+  });
+
+  it('renders the PageTitle component', () => {
+    const wrapper = mountSnmpAlerts();
+    const pageTitle = wrapper.findComponent({ name: 'PageTitle' });
+    expect(pageTitle.exists()).toBe(true);
+    expect(pageTitle.props('title')).toBe('appPageTitle.snmpAlerts');
+  });
+
+  it('renders the Add Destination button', () => {
+    const wrapper = mountSnmpAlerts();
+    const buttons = wrapper.findAll('button');
+    const addBtn = buttons.find((b) =>
+      b.text().includes('pageSnmpAlerts.addDestination'),
+    );
+    expect(addBtn).toBeDefined();
+  });
+
+  // ── Loading state ─────────────────────────────────────────────────────
+
+  it('isBusy is true when loading', () => {
+    const wrapper = mountSnmpAlerts({ isLoading: ref(true) });
+    expect(wrapper.vm.isBusy).toBe(true);
+  });
+
+  it('isBusy is false when not loading', () => {
+    const wrapper = mountSnmpAlerts({ isLoading: ref(false) });
+    expect(wrapper.vm.isBusy).toBe(false);
+  });
+
+  it('starts the loader when loading on mount', () => {
+    mountSnmpAlerts({ isLoading: ref(true) });
+    expect(startLoaderMock).toHaveBeenCalled();
+  });
+
+  it('ends the loader when the query enters an error state', async () => {
+    const isError = ref(false);
+    mountSnmpAlerts({ isError });
+
+    endLoaderMock.mockClear();
+    isError.value = true;
+    await nextTick();
+
+    expect(endLoaderMock).toHaveBeenCalled();
+  });
+
+  // ── Data display ──────────────────────────────────────────────────────
+
+  it('renders alert rows in the table', async () => {
+    const wrapper = mountSnmpAlerts({ snmpAlerts: ref(MOCK_ALERTS) });
+    await wrapper.vm.$nextTick();
+    const tableText = wrapper.find('table').text();
+    expect(tableText).toContain('192.168.1.10');
+    expect(tableText).toContain('10.0.0.1');
+  });
+
+  it('shows empty message when no alerts', async () => {
+    const wrapper = mountSnmpAlerts({ snmpAlerts: ref([]) });
+    await wrapper.vm.$nextTick();
+    expect(wrapper.vm.tableItems.length).toBe(0);
+    expect(wrapper.find('table').text()).toContain('global.table.emptyMessage');
+  });
+
+  it('tableItems adds delete action to each row', async () => {
+    const wrapper = mountSnmpAlerts({ snmpAlerts: ref(MOCK_ALERTS) });
+    await wrapper.vm.$nextTick();
+    expect(wrapper.vm.tableItems[0].actions).toHaveLength(1);
+    expect(wrapper.vm.tableItems[0].actions[0].value).toBe('delete');
+  });
+
+  // ── Selection ─────────────────────────────────────────────────────────
+
+  it('toggleAll(true) marks all alerts as selected', async () => {
+    const wrapper = mountSnmpAlerts({ snmpAlerts: ref(MOCK_ALERTS) });
+    await wrapper.vm.$nextTick();
+
+    wrapper.vm.toggleAll(true);
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.snmpAlertsData.every((a) => a.isSelected)).toBe(true);
+  });
+
+  it('toggleAll(false) clears all selections', async () => {
+    const wrapper = mountSnmpAlerts({ snmpAlerts: ref(MOCK_ALERTS) });
+    await wrapper.vm.$nextTick();
+
+    wrapper.vm.toggleAll(true);
+    await wrapper.vm.$nextTick();
+    wrapper.vm.toggleAll(false);
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.snmpAlertsData.some((a) => a.isSelected)).toBe(false);
+  });
+
+  it('clears selection when the clear-selected event is emitted', async () => {
+    const wrapper = mountSnmpAlerts({ snmpAlerts: ref(MOCK_ALERTS) });
+    await wrapper.vm.$nextTick();
+
+    wrapper.vm.toggleAll(true);
+    await wrapper.vm.$nextTick();
+
+    eventBus.emit('clear-selected');
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.snmpAlertsData.every((a) => !a.isSelected)).toBe(true);
+  });
+
+  // ── Add destination ───────────────────────────────────────────────────
+
+  it('calls addDestination with correct payload on modal ok', async () => {
+    const addDestination = vi.fn().mockResolvedValue(undefined);
+    const wrapper = mountSnmpAlerts({ addDestination });
+    await wrapper.vm.$nextTick();
+
+    await wrapper.vm.onModalOk({ ipAddress: '192.168.1.5', port: '162' });
+    await flushPromises();
+
+    expect(addDestination).toHaveBeenCalledWith({
+      Destination: 'snmp://192.168.1.5:162',
+      SubscriptionType: 'SNMPTrap',
+      Protocol: 'SNMPv2c',
+    });
+  });
+
+  it('builds destination without port when port is empty', async () => {
+    const addDestination = vi.fn().mockResolvedValue(undefined);
+    const wrapper = mountSnmpAlerts({ addDestination });
+
+    await wrapper.vm.onModalOk({ ipAddress: '10.0.0.1', port: '' });
+    await flushPromises();
+
+    expect(addDestination).toHaveBeenCalledWith(
+      expect.objectContaining({ Destination: 'snmp://10.0.0.1' }),
+    );
+  });
+
+  it('shows success toast after adding a destination', async () => {
+    const addDestination = vi.fn().mockResolvedValue(undefined);
+    const wrapper = mountSnmpAlerts({ addDestination });
+
+    await wrapper.vm.onModalOk({ ipAddress: '10.0.0.1', port: '162' });
+    await flushPromises();
+
+    expect(mockSuccessToast).toHaveBeenCalledWith(
+      'Successfully added SNMP alert destination.',
+    );
+  });
+
+  it('shows error toast when addDestination fails', async () => {
+    const addDestination = vi.fn().mockRejectedValue(new Error('fail'));
+    const wrapper = mountSnmpAlerts({ addDestination });
+
+    await wrapper.vm.onModalOk({ ipAddress: '10.0.0.1', port: '162' });
+    await flushPromises();
+
+    expect(mockErrorToast).toHaveBeenCalledWith(
+      'Error in adding SNMP alert destination',
+    );
+  });
+
+  it('does NOT call refetch after addDestination — onSuccess invalidation handles it', async () => {
+    const refetch = vi.fn();
+    const addDestination = vi.fn().mockResolvedValue(undefined);
+    const wrapper = mountSnmpAlerts({ addDestination, refetch });
+
+    await wrapper.vm.onModalOk({ ipAddress: '10.0.0.1', port: '162' });
+    await flushPromises();
+
+    expect(refetch).not.toHaveBeenCalled();
+  });
+
+  // ── Delete single ─────────────────────────────────────────────────────
+
+  it('opens delete modal when row delete action is triggered', async () => {
+    const wrapper = mountSnmpAlerts({ snmpAlerts: ref(MOCK_ALERTS) });
+    await wrapper.vm.$nextTick();
+
+    wrapper.vm.onTableRowAction('delete', MOCK_ALERTS[0]);
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.openDeleteModal).toBe(true);
+    expect(wrapper.vm.deleteType).toBe('singleEntry');
+  });
+
+  it('calls deleteDestination with the correct id', async () => {
+    const deleteDestination = vi.fn().mockResolvedValue(undefined);
+    const wrapper = mountSnmpAlerts({
+      snmpAlerts: ref(MOCK_ALERTS),
+      deleteDestination,
+    });
+    await wrapper.vm.$nextTick();
+
+    wrapper.vm.onTableRowAction('delete', MOCK_ALERTS[0]);
+    await wrapper.vm.$nextTick();
+    await wrapper.vm.handleOk('singleEntry');
+    await flushPromises();
+
+    expect(deleteDestination).toHaveBeenCalledWith('sub-1');
+  });
+
+  it('shows success toast after deleting a destination', async () => {
+    const deleteDestination = vi.fn().mockResolvedValue(undefined);
+    const wrapper = mountSnmpAlerts({
+      snmpAlerts: ref(MOCK_ALERTS),
+      deleteDestination,
+    });
+
+    wrapper.vm.onTableRowAction('delete', MOCK_ALERTS[0]);
+    await wrapper.vm.$nextTick();
+    await wrapper.vm.handleOk('singleEntry');
+    await flushPromises();
+
+    expect(mockSuccessToast).toHaveBeenCalled();
+  });
+
+  it('does NOT call refetch after deleteDestination', async () => {
+    const refetch = vi.fn();
+    const deleteDestination = vi.fn().mockResolvedValue(undefined);
+    const wrapper = mountSnmpAlerts({
+      snmpAlerts: ref(MOCK_ALERTS),
+      deleteDestination,
+      refetch,
+    });
+
+    wrapper.vm.onTableRowAction('delete', MOCK_ALERTS[0]);
+    await wrapper.vm.$nextTick();
+    await wrapper.vm.handleOk('singleEntry');
+    await flushPromises();
+
+    expect(refetch).not.toHaveBeenCalled();
+  });
+
+  // ── Delete multiple ───────────────────────────────────────────────────
+
+  it('opens delete modal for batch delete', async () => {
+    const wrapper = mountSnmpAlerts({ snmpAlerts: ref(MOCK_ALERTS) });
+    await wrapper.vm.$nextTick();
+
+    wrapper.vm.onBatchAction('delete');
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.openDeleteModal).toBe(true);
+    expect(wrapper.vm.deleteType).toBe('selectedEntries');
+  });
+
+  it('calls deleteMultipleDestinations with selected rows', async () => {
+    const deleteMultipleDestinations = vi
+      .fn()
+      .mockResolvedValue({ successCount: 2, errorCount: 0 });
+    const wrapper = mountSnmpAlerts({
+      snmpAlerts: ref(MOCK_ALERTS),
+      deleteMultipleDestinations,
+    });
+    await wrapper.vm.$nextTick();
+
+    // Simulate selected rows via the composable's selectedRowsList
+    wrapper.vm.onBatchAction('delete');
+    await wrapper.vm.$nextTick();
+    await wrapper.vm.handleOk('selectedEntries');
+    await flushPromises();
+
+    expect(deleteMultipleDestinations).toHaveBeenCalled();
+  });
+
+  it('does NOT call refetch after deleteMultipleDestinations', async () => {
+    const refetch = vi.fn();
+    const deleteMultipleDestinations = vi
+      .fn()
+      .mockResolvedValue({ successCount: 1, errorCount: 0 });
+    const wrapper = mountSnmpAlerts({
+      snmpAlerts: ref(MOCK_ALERTS),
+      deleteMultipleDestinations,
+      refetch,
+    });
+
+    wrapper.vm.onBatchAction('delete');
+    await wrapper.vm.$nextTick();
+    await wrapper.vm.handleOk('selectedEntries');
+    await flushPromises();
+
+    expect(refetch).not.toHaveBeenCalled();
+  });
+
+  // ── onBeforeRouteLeave ────────────────────────────────────────────────
+
+  it('registers an onBeforeRouteLeave hook', () => {
+    mountSnmpAlerts();
+    expect(onBeforeRouteLeaveMock).toHaveBeenCalled();
+  });
+
+  // ── defineExpose ──────────────────────────────────────────────────────
+
+  it('exposes a refetch function via defineExpose', () => {
+    const refetchMock = vi.fn();
+    const wrapper = mountSnmpAlerts({ refetch: refetchMock });
+    expect(typeof wrapper.vm.refetch).toBe('function');
+  });
+});

--- a/tests/unit/composables/useFactoryReset.spec.js
+++ b/tests/unit/composables/useFactoryReset.spec.js
@@ -1,0 +1,262 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('@tanstack/vue-query', () => ({
+  useMutation: vi.fn(),
+}));
+
+vi.mock('@/store/api', () => ({
+  default: {
+    post: vi.fn(),
+  },
+}));
+
+vi.mock('@/i18n', () => ({
+  default: {
+    global: {
+      t: vi.fn((key) => key),
+    },
+  },
+}));
+
+import { useMutation } from '@tanstack/vue-query';
+import api from '@/store/api';
+import i18n from '@/i18n';
+import { useFactoryReset } from '@/api/composables/useFactoryReset';
+import { ref } from 'vue';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const makeMockMutation = (overrides = {}) => ({
+  mutateAsync: vi.fn(),
+  isPending: ref(false),
+  ...overrides,
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useFactoryReset', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── return shape ─────────────────────────────────────────────────────────
+
+  describe('return shape', () => {
+    it('exposes resetToDefaults, resetBios, and isResetting', () => {
+      useMutation.mockReturnValue(makeMockMutation());
+
+      const result = useFactoryReset();
+
+      expect(typeof result.resetToDefaults).toBe('function');
+      expect(typeof result.resetBios).toBe('function');
+      expect('isResetting' in result).toBe(true);
+    });
+
+    it('does not expose raw mutation objects', () => {
+      useMutation.mockReturnValue(makeMockMutation());
+
+      const result = useFactoryReset();
+
+      expect(result.resetToDefaultsMutation).toBeUndefined();
+      expect(result.resetBiosMutation).toBeUndefined();
+    });
+  });
+
+  // ── isResetting ──────────────────────────────────────────────────────────
+
+  describe('isResetting', () => {
+    it('is false when neither mutation is pending', () => {
+      useMutation.mockReturnValue(makeMockMutation({ isPending: ref(false) }));
+
+      const { isResetting } = useFactoryReset();
+
+      expect(isResetting.value).toBe(false);
+    });
+
+    it('is true when resetToDefaults mutation is pending', () => {
+      useMutation
+        .mockReturnValueOnce(makeMockMutation({ isPending: ref(true) })) // resetToDefaults
+        .mockReturnValueOnce(makeMockMutation({ isPending: ref(false) })); // resetBios
+
+      const { isResetting } = useFactoryReset();
+
+      expect(isResetting.value).toBe(true);
+    });
+
+    it('is true when resetBios mutation is pending', () => {
+      useMutation
+        .mockReturnValueOnce(makeMockMutation({ isPending: ref(false) })) // resetToDefaults
+        .mockReturnValueOnce(makeMockMutation({ isPending: ref(true) })); // resetBios
+
+      const { isResetting } = useFactoryReset();
+
+      expect(isResetting.value).toBe(true);
+    });
+  });
+
+  // ── resetToDefaults mutationFn ────────────────────────────────────────────
+
+  describe('resetToDefaults mutationFn', () => {
+    let capturedResetToDefaultsConfig;
+
+    beforeEach(() => {
+      let callCount = 0;
+      useMutation.mockImplementation((config) => {
+        if (callCount === 0) capturedResetToDefaultsConfig = config;
+        callCount++;
+        return makeMockMutation();
+      });
+      useFactoryReset();
+    });
+
+    it('posts to the correct ResetToDefaults endpoint', async () => {
+      api.post.mockResolvedValue({});
+      i18n.global.t.mockReturnValue('success');
+
+      await capturedResetToDefaultsConfig.mutationFn();
+
+      expect(api.post).toHaveBeenCalledWith(
+        '/redfish/v1/Managers/bmc/Actions/Manager.ResetToDefaults',
+        { ResetType: 'ResetAll' },
+      );
+    });
+
+    it('returns the translated success message on success', async () => {
+      const successMsg = 'pageFactoryReset.toast.resetToDefaultsSuccess';
+      api.post.mockResolvedValue({});
+      i18n.global.t.mockReturnValue(successMsg);
+
+      const result = await capturedResetToDefaultsConfig.mutationFn();
+
+      expect(result).toBe(successMsg);
+      expect(i18n.global.t).toHaveBeenCalledWith(
+        'pageFactoryReset.toast.resetToDefaultsSuccess',
+      );
+    });
+
+    it('throws a translated error when the API call fails', async () => {
+      const errMsg = 'pageFactoryReset.toast.resetToDefaultsError';
+      api.post.mockRejectedValue(new Error('Network error'));
+      i18n.global.t.mockReturnValue(errMsg);
+
+      await expect(capturedResetToDefaultsConfig.mutationFn()).rejects.toThrow(
+        errMsg,
+      );
+      expect(i18n.global.t).toHaveBeenCalledWith(
+        'pageFactoryReset.toast.resetToDefaultsError',
+      );
+    });
+
+    it('logs the raw error before throwing', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const rawError = new Error('Network error');
+      api.post.mockRejectedValue(rawError);
+      i18n.global.t.mockReturnValue('error');
+
+      await expect(
+        capturedResetToDefaultsConfig.mutationFn(),
+      ).rejects.toThrow();
+
+      expect(consoleSpy).toHaveBeenCalledWith('Factory Reset: ', rawError);
+      consoleSpy.mockRestore();
+    });
+  });
+
+  // ── resetBios mutationFn ─────────────────────────────────────────────────
+
+  describe('resetBios mutationFn', () => {
+    let capturedResetBiosConfig;
+
+    beforeEach(() => {
+      let callCount = 0;
+      useMutation.mockImplementation((config) => {
+        if (callCount === 1) capturedResetBiosConfig = config;
+        callCount++;
+        return makeMockMutation();
+      });
+      useFactoryReset();
+    });
+
+    it('posts to the correct ResetBios endpoint', async () => {
+      api.post.mockResolvedValue({});
+      i18n.global.t.mockReturnValue('success');
+
+      await capturedResetBiosConfig.mutationFn();
+
+      expect(api.post).toHaveBeenCalledWith(
+        '/redfish/v1/Systems/system/Bios/Actions/Bios.ResetBios',
+      );
+    });
+
+    it('returns the translated success message on success', async () => {
+      const successMsg = 'pageFactoryReset.toast.resetBiosSuccess';
+      api.post.mockResolvedValue({});
+      i18n.global.t.mockReturnValue(successMsg);
+
+      const result = await capturedResetBiosConfig.mutationFn();
+
+      expect(result).toBe(successMsg);
+      expect(i18n.global.t).toHaveBeenCalledWith(
+        'pageFactoryReset.toast.resetBiosSuccess',
+      );
+    });
+
+    it('throws a translated error when the API call fails', async () => {
+      const errMsg = 'pageFactoryReset.toast.resetBiosError';
+      api.post.mockRejectedValue(new Error('Network error'));
+      i18n.global.t.mockReturnValue(errMsg);
+
+      await expect(capturedResetBiosConfig.mutationFn()).rejects.toThrow(
+        errMsg,
+      );
+      expect(i18n.global.t).toHaveBeenCalledWith(
+        'pageFactoryReset.toast.resetBiosError',
+      );
+    });
+
+    it('logs the raw error before throwing', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const rawError = new Error('BIOS error');
+      api.post.mockRejectedValue(rawError);
+      i18n.global.t.mockReturnValue('error');
+
+      await expect(capturedResetBiosConfig.mutationFn()).rejects.toThrow();
+
+      expect(consoleSpy).toHaveBeenCalledWith('Factory Reset: ', rawError);
+      consoleSpy.mockRestore();
+    });
+  });
+
+  // ── integration ──────────────────────────────────────────────────────────
+
+  describe('integration', () => {
+    it('resetBios and resetToDefaults call their respective mutateAsync', async () => {
+      const biosAsync = vi.fn().mockResolvedValue('bios success');
+      const defaultsAsync = vi.fn().mockResolvedValue('defaults success');
+
+      let callCount = 0;
+      useMutation.mockImplementation(() => {
+        callCount++;
+        return makeMockMutation({
+          mutateAsync: callCount === 1 ? defaultsAsync : biosAsync,
+        });
+      });
+
+      const { resetToDefaults, resetBios } = useFactoryReset();
+
+      await resetToDefaults();
+      expect(defaultsAsync).toHaveBeenCalled();
+
+      await resetBios();
+      expect(biosAsync).toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/composables/useSessions.spec.js
+++ b/tests/unit/composables/useSessions.spec.js
@@ -1,0 +1,434 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ref } from 'vue';
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('@/api/composables/useAllSubResources', () => ({
+  useRedfishCollection: vi.fn(),
+}));
+
+vi.mock('@tanstack/vue-query', () => ({
+  useMutation: vi.fn(),
+  useQueryClient: vi.fn(() => ({
+    invalidateQueries: vi.fn(),
+  })),
+}));
+
+vi.mock('@/store/api', () => ({
+  default: {
+    delete: vi.fn(),
+    all: vi.fn(),
+  },
+  getResponseCount: vi.fn(),
+}));
+
+vi.mock('@/i18n', () => ({
+  default: {
+    global: {
+      t: vi.fn((key) => key),
+    },
+  },
+}));
+
+vi.mock('@/api/composables/shared/queryConfig', () => ({
+  RedfishQueryPresets: {
+    sensors: { staleTime: 0 },
+  },
+}));
+
+import { useRedfishCollection } from '@/api/composables/useAllSubResources';
+import { useMutation, useQueryClient } from '@tanstack/vue-query';
+import api, { getResponseCount } from '@/store/api';
+import i18n from '@/i18n';
+import { useSessions } from '@/api/composables/useSessions';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const makeCollectionQuery = (overrides = {}) => ({
+  data: ref(null),
+  isLoading: ref(false),
+  isFetching: ref(false),
+  error: ref(null),
+  isError: ref(false),
+  refetch: vi.fn(),
+  ...overrides,
+});
+
+const makeMockMutation = (overrides = {}) => ({
+  mutateAsync: vi.fn(),
+  isPending: ref(false),
+  ...overrides,
+});
+
+const SESSION_A = {
+  '@odata.id': '/redfish/v1/SessionService/Sessions/1',
+  Context: 'ctx-1',
+  UserName: 'alice',
+  ClientOriginIPAddress: '::ffff:192.168.1.1',
+};
+
+const SESSION_B = {
+  '@odata.id': '/redfish/v1/SessionService/Sessions/2',
+  Context: 'ctx-2',
+  UserName: 'bob',
+  ClientOriginIPAddress: '10.0.0.2',
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useSessions', () => {
+  let mockQueryClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQueryClient = { invalidateQueries: vi.fn() };
+    useQueryClient.mockReturnValue(mockQueryClient);
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  // ── sessions computed ────────────────────────────────────────────────────
+
+  describe('sessions computed', () => {
+    it('returns empty array when data is null', () => {
+      useRedfishCollection.mockReturnValue(makeCollectionQuery({ data: ref(null) }));
+      useMutation.mockReturnValue(makeMockMutation());
+
+      const { sessions } = useSessions();
+
+      expect(sessions.value).toEqual([]);
+    });
+
+    it('maps raw Redfish session data to SessionDisplay shape', () => {
+      useRedfishCollection.mockReturnValue(
+        makeCollectionQuery({ data: ref([SESSION_A]) }),
+      );
+      useMutation.mockReturnValue(makeMockMutation());
+
+      const { sessions } = useSessions();
+
+      expect(sessions.value).toHaveLength(1);
+      expect(sessions.value[0]).toMatchObject({
+        clientID: 'ctx-1',
+        username: 'alice',
+        ipAddress: '192.168.1.1',
+        uri: '/redfish/v1/SessionService/Sessions/1',
+      });
+    });
+
+    it('strips ::ffff: prefix from IPv4-mapped IPv6 addresses', () => {
+      useRedfishCollection.mockReturnValue(
+        makeCollectionQuery({ data: ref([SESSION_A]) }),
+      );
+      useMutation.mockReturnValue(makeMockMutation());
+
+      const { sessions } = useSessions();
+
+      expect(sessions.value[0].ipAddress).toBe('192.168.1.1');
+    });
+
+    it('keeps plain IPv4 address unchanged', () => {
+      useRedfishCollection.mockReturnValue(
+        makeCollectionQuery({ data: ref([SESSION_B]) }),
+      );
+      useMutation.mockReturnValue(makeMockMutation());
+
+      const { sessions } = useSessions();
+
+      expect(sessions.value[0].ipAddress).toBe('10.0.0.2');
+    });
+
+    it('falls back to "--" for missing Context', () => {
+      const session = { ...SESSION_A, Context: undefined };
+      useRedfishCollection.mockReturnValue(
+        makeCollectionQuery({ data: ref([session]) }),
+      );
+      useMutation.mockReturnValue(makeMockMutation());
+
+      const { sessions } = useSessions();
+
+      expect(sessions.value[0].clientID).toBe('--');
+    });
+
+    it('falls back to "--" for missing UserName', () => {
+      const session = { ...SESSION_A, UserName: undefined };
+      useRedfishCollection.mockReturnValue(
+        makeCollectionQuery({ data: ref([session]) }),
+      );
+      useMutation.mockReturnValue(makeMockMutation());
+
+      const { sessions } = useSessions();
+
+      expect(sessions.value[0].username).toBe('--');
+    });
+
+    it('falls back to "--" for missing ClientOriginIPAddress', () => {
+      const session = { ...SESSION_A, ClientOriginIPAddress: undefined };
+      useRedfishCollection.mockReturnValue(
+        makeCollectionQuery({ data: ref([session]) }),
+      );
+      useMutation.mockReturnValue(makeMockMutation());
+
+      const { sessions } = useSessions();
+
+      expect(sessions.value[0].ipAddress).toBe('--');
+    });
+
+    it('includes a disconnect action for each session', () => {
+      useRedfishCollection.mockReturnValue(
+        makeCollectionQuery({ data: ref([SESSION_A]) }),
+      );
+      useMutation.mockReturnValue(makeMockMutation());
+
+      const { sessions } = useSessions();
+
+      expect(sessions.value[0].actions).toHaveLength(1);
+      expect(sessions.value[0].actions[0].value).toBe('disconnect');
+    });
+
+    it('maps multiple sessions correctly', () => {
+      useRedfishCollection.mockReturnValue(
+        makeCollectionQuery({ data: ref([SESSION_A, SESSION_B]) }),
+      );
+      useMutation.mockReturnValue(makeMockMutation());
+
+      const { sessions } = useSessions();
+
+      expect(sessions.value).toHaveLength(2);
+      expect(sessions.value[1].username).toBe('bob');
+    });
+  });
+
+  // ── isLoading / isFetching / isError ────────────────────────────────────
+
+  describe('query state passthrough', () => {
+    it('exposes isLoading from the collection query', () => {
+      useRedfishCollection.mockReturnValue(
+        makeCollectionQuery({ isLoading: ref(true) }),
+      );
+      useMutation.mockReturnValue(makeMockMutation());
+
+      const { isLoading } = useSessions();
+
+      expect(isLoading.value).toBe(true);
+    });
+
+    it('exposes isFetching from the collection query', () => {
+      useRedfishCollection.mockReturnValue(
+        makeCollectionQuery({ isFetching: ref(true) }),
+      );
+      useMutation.mockReturnValue(makeMockMutation());
+
+      const { isFetching } = useSessions();
+
+      expect(isFetching.value).toBe(true);
+    });
+
+    it('exposes isError from the collection query', () => {
+      useRedfishCollection.mockReturnValue(
+        makeCollectionQuery({ isError: ref(true) }),
+      );
+      useMutation.mockReturnValue(makeMockMutation());
+
+      const { isError } = useSessions();
+
+      expect(isError.value).toBe(true);
+    });
+
+    it('exposes refetch from the collection query', () => {
+      const refetchFn = vi.fn();
+      useRedfishCollection.mockReturnValue(
+        makeCollectionQuery({ refetch: refetchFn }),
+      );
+      useMutation.mockReturnValue(makeMockMutation());
+
+      const { refetch } = useSessions();
+
+      expect(refetch).toBe(refetchFn);
+    });
+
+    it('exposes isDisconnecting from the mutation isPending', () => {
+      useRedfishCollection.mockReturnValue(makeCollectionQuery());
+      useMutation.mockReturnValue(makeMockMutation({ isPending: ref(true) }));
+
+      const { isDisconnecting } = useSessions();
+
+      expect(isDisconnecting.value).toBe(true);
+    });
+  });
+
+  // ── query config ─────────────────────────────────────────────────────────
+
+  describe('query configuration', () => {
+    it('queries the Sessions collection endpoint', () => {
+      useMutation.mockReturnValue(makeMockMutation());
+
+      useSessions();
+
+      expect(useRedfishCollection).toHaveBeenCalledWith(
+        '/redfish/v1/SessionService/Sessions',
+        expect.objectContaining({ expand: false }),
+      );
+    });
+
+    it('uses the sensors query preset', () => {
+      useMutation.mockReturnValue(makeMockMutation());
+
+      useSessions();
+
+      expect(useRedfishCollection).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ queryConfig: expect.any(Object) }),
+      );
+    });
+  });
+
+  // ── disconnectSessions mutation ──────────────────────────────────────────
+
+  describe('disconnectSessions mutation fn', () => {
+    let capturedConfig;
+
+    beforeEach(() => {
+      useRedfishCollection.mockReturnValue(makeCollectionQuery());
+      useMutation.mockImplementation((config) => {
+        capturedConfig = config;
+        return makeMockMutation();
+      });
+      useSessions();
+    });
+
+    it('deletes other sessions before the current session', async () => {
+      const currentUri = '/redfish/v1/SessionService/Sessions/current';
+      const otherUri = '/redfish/v1/SessionService/Sessions/other';
+      localStorage.setItem('currentSessionUri', currentUri);
+
+      api.delete.mockResolvedValue({});
+      api.all.mockResolvedValue([{}]);
+      getResponseCount.mockReturnValue({ successCount: 2, errorCount: 0 });
+      i18n.global.t.mockReturnValue('success');
+
+      await capturedConfig.mutationFn([currentUri, otherUri]);
+
+      // api.all receives promises array — verify both URIs were deleted
+      expect(api.delete).toHaveBeenCalledWith(otherUri);
+      expect(api.delete).toHaveBeenCalledWith(currentUri);
+
+      // otherUri must appear before currentUri in the promises list
+      const deleteCallOrder = api.delete.mock.calls.map(([uri]) => uri);
+      expect(deleteCallOrder.indexOf(otherUri)).toBeLessThan(
+        deleteCallOrder.indexOf(currentUri),
+      );
+    });
+
+    it('does not separate sessions when no current session URI is stored', async () => {
+      localStorage.removeItem('currentSessionUri');
+      const uris = [
+        '/redfish/v1/SessionService/Sessions/1',
+        '/redfish/v1/SessionService/Sessions/2',
+      ];
+
+      api.delete.mockResolvedValue({});
+      api.all.mockResolvedValue([{}, {}]);
+      getResponseCount.mockReturnValue({ successCount: 2, errorCount: 0 });
+      i18n.global.t.mockReturnValue('success');
+
+      await capturedConfig.mutationFn(uris);
+
+      expect(api.delete).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns success toast message when all deletes succeed', async () => {
+      const successMsg = 'pageSessions.toast.successDelete';
+      api.delete.mockResolvedValue({});
+      api.all.mockResolvedValue([{}]);
+      getResponseCount.mockReturnValue({ successCount: 1, errorCount: 0 });
+      i18n.global.t.mockReturnValue(successMsg);
+
+      const result = await capturedConfig.mutationFn([
+        '/redfish/v1/SessionService/Sessions/1',
+      ]);
+
+      expect(result).toContainEqual({ type: 'success', message: successMsg });
+    });
+
+    it('returns error toast message when a delete fails', async () => {
+      const errorMsg = 'pageSessions.toast.errorDelete';
+      api.delete.mockResolvedValue({});
+      api.all.mockResolvedValue([new Error('fail')]);
+      getResponseCount.mockReturnValue({ successCount: 0, errorCount: 1 });
+      i18n.global.t.mockReturnValue(errorMsg);
+
+      const result = await capturedConfig.mutationFn([
+        '/redfish/v1/SessionService/Sessions/1',
+      ]);
+
+      expect(result).toContainEqual({ type: 'error', message: errorMsg });
+    });
+
+    it('returns both success and error messages when partially failing', async () => {
+      api.delete.mockResolvedValue({});
+      api.all.mockResolvedValue([{}, new Error('fail')]);
+      getResponseCount.mockReturnValue({ successCount: 1, errorCount: 1 });
+      i18n.global.t.mockImplementation((key) => key);
+
+      const result = await capturedConfig.mutationFn([
+        '/redfish/v1/SessionService/Sessions/1',
+        '/redfish/v1/SessionService/Sessions/2',
+      ]);
+
+      expect(result.some((m) => m.type === 'success')).toBe(true);
+      expect(result.some((m) => m.type === 'error')).toBe(true);
+    });
+
+    it('onSuccess invalidates the sessions collection query', () => {
+      capturedConfig.onSuccess();
+
+      expect(mockQueryClient.invalidateQueries).toHaveBeenCalledWith({
+        queryKey: [
+          'redfish',
+          'collection',
+          '/redfish/v1/SessionService/Sessions',
+        ],
+      });
+    });
+  });
+
+  // ── disconnectSessions wrapper ───────────────────────────────────────────
+
+  describe('disconnectSessions', () => {
+    it('calls mutateAsync with the provided URIs', async () => {
+      useRedfishCollection.mockReturnValue(makeCollectionQuery());
+      const mutateAsync = vi.fn().mockResolvedValue([]);
+      useMutation.mockReturnValue(makeMockMutation({ mutateAsync }));
+
+      const { disconnectSessions } = useSessions();
+      await disconnectSessions(['/redfish/v1/SessionService/Sessions/1']);
+
+      expect(mutateAsync).toHaveBeenCalledWith([
+        '/redfish/v1/SessionService/Sessions/1',
+      ]);
+    });
+
+    it('returns the toast messages from mutateAsync', async () => {
+      useRedfishCollection.mockReturnValue(makeCollectionQuery());
+      const messages = [{ type: 'success', message: 'ok' }];
+      const mutateAsync = vi.fn().mockResolvedValue(messages);
+      useMutation.mockReturnValue(makeMockMutation({ mutateAsync }));
+
+      const { disconnectSessions } = useSessions();
+      const result = await disconnectSessions([
+        '/redfish/v1/SessionService/Sessions/1',
+      ]);
+
+      expect(result).toEqual(messages);
+    });
+  });
+});

--- a/tests/unit/composables/useSnmpAlerts.spec.js
+++ b/tests/unit/composables/useSnmpAlerts.spec.js
@@ -1,0 +1,437 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('@/api/composables/useAllSubResources', () => ({
+  useNavigatedCollection: vi.fn(),
+  navigateToCollection: vi.fn(),
+}));
+
+vi.mock('@tanstack/vue-query', () => ({
+  useMutation: vi.fn(),
+  useQueryClient: vi.fn(() => ({ invalidateQueries: vi.fn() })),
+}));
+
+vi.mock('@/store/api', () => ({
+  default: {
+    post: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock('@/i18n', () => ({
+  default: {
+    global: {
+      t: vi.fn((key) => key),
+    },
+  },
+}));
+
+import {
+  useNavigatedCollection,
+  navigateToCollection,
+} from '@/api/composables/useAllSubResources';
+import { useMutation, useQueryClient } from '@tanstack/vue-query';
+import api from '@/store/api';
+import i18n from '@/i18n';
+import { useSnmpAlerts } from '@/api/composables/useSnmpAlerts';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const SNMP_QUERY_KEY = [
+  'redfish',
+  'navigatedCollection',
+  'EventService',
+  'Subscriptions',
+];
+
+const makeNavigatedQuery = (overrides = {}) => ({
+  data: ref(null),
+  isLoading: ref(false),
+  isError: ref(false),
+  error: ref(null),
+  refetch: vi.fn(),
+  ...overrides,
+});
+
+const makeMockMutation = (overrides = {}) => ({
+  mutateAsync: vi.fn(),
+  isPending: ref(false),
+  ...overrides,
+});
+
+const RAW_SUB_WITH_PROTOCOL = {
+  '@odata.id': '/redfish/v1/EventService/Subscriptions/1',
+  Id: 'sub-1',
+  Destination: 'snmp://192.168.1.10:162',
+  SubscriptionType: 'SNMPTrap',
+  Protocol: 'SNMPv2c',
+};
+
+const RAW_SUB_NO_PROTOCOL = {
+  '@odata.id': '/redfish/v1/EventService/Subscriptions/2',
+  Id: 'sub-2',
+  Destination: '10.0.0.1:161',
+  SubscriptionType: 'SNMPTrap',
+  Protocol: 'SNMPv2c',
+};
+
+const RAW_SUB_NO_PORT = {
+  '@odata.id': '/redfish/v1/EventService/Subscriptions/3',
+  Id: 'sub-3',
+  Destination: 'snmp://10.0.0.2',
+  SubscriptionType: 'SNMPTrap',
+  Protocol: 'SNMPv2c',
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useSnmpAlerts', () => {
+  let mockQueryClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQueryClient = { invalidateQueries: vi.fn() };
+    useQueryClient.mockReturnValue(mockQueryClient);
+  });
+
+  // ── snmpAlerts computed ──────────────────────────────────────────────────
+
+  describe('snmpAlerts computed', () => {
+    it('returns empty array when data is null', () => {
+      useNavigatedCollection.mockReturnValue(makeNavigatedQuery());
+      useMutation.mockReturnValue(makeMockMutation());
+
+      const { snmpAlerts } = useSnmpAlerts();
+
+      expect(snmpAlerts.value).toEqual([]);
+    });
+
+    it('parses ip and port from protocol-prefixed destination', () => {
+      useNavigatedCollection.mockReturnValue(
+        makeNavigatedQuery({ data: ref([RAW_SUB_WITH_PROTOCOL]) }),
+      );
+      useMutation.mockReturnValue(makeMockMutation());
+
+      const { snmpAlerts } = useSnmpAlerts();
+
+      expect(snmpAlerts.value[0].ip).toBe('192.168.1.10');
+      expect(snmpAlerts.value[0].port).toBe('162');
+    });
+
+    it('parses ip and port from plain host:port destination', () => {
+      useNavigatedCollection.mockReturnValue(
+        makeNavigatedQuery({ data: ref([RAW_SUB_NO_PROTOCOL]) }),
+      );
+      useMutation.mockReturnValue(makeMockMutation());
+
+      const { snmpAlerts } = useSnmpAlerts();
+
+      expect(snmpAlerts.value[0].ip).toBe('10.0.0.1');
+      expect(snmpAlerts.value[0].port).toBe('161');
+    });
+
+    it('sets port to empty string when no port is present', () => {
+      useNavigatedCollection.mockReturnValue(
+        makeNavigatedQuery({ data: ref([RAW_SUB_NO_PORT]) }),
+      );
+      useMutation.mockReturnValue(makeMockMutation());
+
+      const { snmpAlerts } = useSnmpAlerts();
+
+      expect(snmpAlerts.value[0].port).toBe('');
+    });
+
+    it('maps isSelected to false by default', () => {
+      useNavigatedCollection.mockReturnValue(
+        makeNavigatedQuery({ data: ref([RAW_SUB_WITH_PROTOCOL]) }),
+      );
+      useMutation.mockReturnValue(makeMockMutation());
+
+      const { snmpAlerts } = useSnmpAlerts();
+
+      expect(snmpAlerts.value[0].isSelected).toBe(false);
+    });
+
+    it('maps multiple subscriptions correctly', () => {
+      useNavigatedCollection.mockReturnValue(
+        makeNavigatedQuery({
+          data: ref([RAW_SUB_WITH_PROTOCOL, RAW_SUB_NO_PROTOCOL]),
+        }),
+      );
+      useMutation.mockReturnValue(makeMockMutation());
+
+      const { snmpAlerts } = useSnmpAlerts();
+
+      expect(snmpAlerts.value).toHaveLength(2);
+      expect(snmpAlerts.value[1].id).toBe('sub-2');
+    });
+  });
+
+  // ── query state passthrough ──────────────────────────────────────────────
+
+  describe('query state passthrough', () => {
+    it('exposes isLoading from navigated query', () => {
+      useNavigatedCollection.mockReturnValue(
+        makeNavigatedQuery({ isLoading: ref(true) }),
+      );
+      useMutation.mockReturnValue(makeMockMutation());
+
+      const { isLoading } = useSnmpAlerts();
+
+      expect(isLoading.value).toBe(true);
+    });
+
+    it('exposes isError from navigated query', () => {
+      useNavigatedCollection.mockReturnValue(
+        makeNavigatedQuery({ isError: ref(true) }),
+      );
+      useMutation.mockReturnValue(makeMockMutation());
+
+      const { isError } = useSnmpAlerts();
+
+      expect(isError.value).toBe(true);
+    });
+
+    it('exposes refetch from navigated query', () => {
+      const refetchFn = vi.fn();
+      useNavigatedCollection.mockReturnValue(
+        makeNavigatedQuery({ refetch: refetchFn }),
+      );
+      useMutation.mockReturnValue(makeMockMutation());
+
+      const { refetch } = useSnmpAlerts();
+
+      expect(refetch).toBe(refetchFn);
+    });
+  });
+
+  // ── addDestination mutationFn ────────────────────────────────────────────
+
+  describe('addDestination mutationFn', () => {
+    let capturedAddConfig;
+
+    beforeEach(() => {
+      useNavigatedCollection.mockReturnValue(makeNavigatedQuery());
+      let callCount = 0;
+      useMutation.mockImplementation((config) => {
+        if (callCount === 0) capturedAddConfig = config;
+        callCount++;
+        return makeMockMutation();
+      });
+      useSnmpAlerts();
+    });
+
+    it('navigates to the subscriptions collection and posts the payload', async () => {
+      const collectionUrl = '/redfish/v1/EventService/Subscriptions';
+      navigateToCollection.mockResolvedValue(collectionUrl);
+      api.post.mockResolvedValue({});
+
+      const payload = {
+        Destination: 'snmp://10.0.0.1:162',
+        SubscriptionType: 'SNMPTrap',
+        Protocol: 'SNMPv2c',
+      };
+
+      await capturedAddConfig.mutationFn(payload);
+
+      expect(navigateToCollection).toHaveBeenCalledWith([
+        'EventService',
+        'Subscriptions',
+      ]);
+      expect(api.post).toHaveBeenCalledWith(collectionUrl, payload);
+    });
+
+    it('throws a translated error when the API call fails', async () => {
+      navigateToCollection.mockRejectedValue(new Error('Network error'));
+      i18n.global.t.mockReturnValue(
+        'pageSnmpAlerts.toast.errorAddDestination',
+      );
+
+      await expect(
+        capturedAddConfig.mutationFn({
+          Destination: 'snmp://10.0.0.1',
+          SubscriptionType: 'SNMPTrap',
+          Protocol: 'SNMPv2c',
+        }),
+      ).rejects.toThrow('pageSnmpAlerts.toast.errorAddDestination');
+    });
+
+    it('onSuccess invalidates the subscriptions query', () => {
+      capturedAddConfig.onSuccess();
+
+      expect(mockQueryClient.invalidateQueries).toHaveBeenCalledWith({
+        queryKey: SNMP_QUERY_KEY,
+      });
+    });
+  });
+
+  // ── deleteDestination mutationFn ─────────────────────────────────────────
+
+  describe('deleteDestination mutationFn', () => {
+    let capturedDeleteConfig;
+
+    beforeEach(() => {
+      useNavigatedCollection.mockReturnValue(makeNavigatedQuery());
+      let callCount = 0;
+      useMutation.mockImplementation((config) => {
+        if (callCount === 1) capturedDeleteConfig = config;
+        callCount++;
+        return makeMockMutation();
+      });
+      useSnmpAlerts();
+    });
+
+    it('navigates to the subscriptions collection and deletes by id', async () => {
+      const collectionUrl = '/redfish/v1/EventService/Subscriptions';
+      navigateToCollection.mockResolvedValue(collectionUrl);
+      api.delete.mockResolvedValue({});
+
+      await capturedDeleteConfig.mutationFn('sub-1');
+
+      expect(api.delete).toHaveBeenCalledWith(
+        `${collectionUrl}/sub-1`,
+      );
+    });
+
+    it('throws a translated error (with id) when the delete fails', async () => {
+      navigateToCollection.mockRejectedValue(new Error('Network error'));
+      i18n.global.t.mockReturnValue(
+        'pageSnmpAlerts.toast.errorDeleteDestination',
+      );
+
+      await expect(capturedDeleteConfig.mutationFn('sub-1')).rejects.toThrow(
+        'pageSnmpAlerts.toast.errorDeleteDestination',
+      );
+
+      expect(i18n.global.t).toHaveBeenCalledWith(
+        'pageSnmpAlerts.toast.errorDeleteDestination',
+        { id: 'sub-1' },
+      );
+    });
+
+    it('onSuccess invalidates the subscriptions query', () => {
+      capturedDeleteConfig.onSuccess();
+
+      expect(mockQueryClient.invalidateQueries).toHaveBeenCalledWith({
+        queryKey: SNMP_QUERY_KEY,
+      });
+    });
+  });
+
+  // ── deleteMultipleDestinations mutationFn ────────────────────────────────
+
+  describe('deleteMultipleDestinations mutationFn', () => {
+    let capturedDeleteMultipleConfig;
+
+    beforeEach(() => {
+      useNavigatedCollection.mockReturnValue(makeNavigatedQuery());
+      let callCount = 0;
+      useMutation.mockImplementation((config) => {
+        if (callCount === 2) capturedDeleteMultipleConfig = config;
+        callCount++;
+        return makeMockMutation();
+      });
+      useSnmpAlerts();
+    });
+
+    it('deletes each destination and returns success/error counts', async () => {
+      const collectionUrl = '/redfish/v1/EventService/Subscriptions';
+      navigateToCollection.mockResolvedValue(collectionUrl);
+      api.delete.mockResolvedValue({});
+
+      const destinations = [
+        { id: 'sub-1' },
+        { id: 'sub-2' },
+      ];
+
+      const result =
+        await capturedDeleteMultipleConfig.mutationFn(destinations);
+
+      expect(api.delete).toHaveBeenCalledTimes(2);
+      expect(result.successCount).toBe(2);
+      expect(result.errorCount).toBe(0);
+    });
+
+    it('counts failed deletes in errorCount', async () => {
+      navigateToCollection.mockResolvedValue(
+        '/redfish/v1/EventService/Subscriptions',
+      );
+      api.delete
+        .mockResolvedValueOnce({})
+        .mockRejectedValueOnce(new Error('fail'));
+
+      const destinations = [{ id: 'sub-1' }, { id: 'sub-2' }];
+
+      const result =
+        await capturedDeleteMultipleConfig.mutationFn(destinations);
+
+      expect(result.successCount).toBe(1);
+      expect(result.errorCount).toBe(1);
+    });
+
+    it('onSuccess invalidates the subscriptions query', () => {
+      capturedDeleteMultipleConfig.onSuccess();
+
+      expect(mockQueryClient.invalidateQueries).toHaveBeenCalledWith({
+        queryKey: SNMP_QUERY_KEY,
+      });
+    });
+  });
+
+  // ── mutation state passthrough ───────────────────────────────────────────
+
+  describe('mutation state passthrough', () => {
+    it('exposes isAddingDestination isPending', () => {
+      useNavigatedCollection.mockReturnValue(makeNavigatedQuery());
+      let callCount = 0;
+      useMutation.mockImplementation(() => {
+        callCount++;
+        return makeMockMutation({
+          isPending: callCount === 1 ? ref(true) : ref(false),
+        });
+      });
+
+      const { isAddingDestination } = useSnmpAlerts();
+
+      expect(isAddingDestination.value).toBe(true);
+    });
+
+    it('exposes isDeletingDestination isPending', () => {
+      useNavigatedCollection.mockReturnValue(makeNavigatedQuery());
+      let callCount = 0;
+      useMutation.mockImplementation(() => {
+        callCount++;
+        return makeMockMutation({
+          isPending: callCount === 2 ? ref(true) : ref(false),
+        });
+      });
+
+      const { isDeletingDestination } = useSnmpAlerts();
+
+      expect(isDeletingDestination.value).toBe(true);
+    });
+
+    it('exposes isDeletingMultiple isPending', () => {
+      useNavigatedCollection.mockReturnValue(makeNavigatedQuery());
+      let callCount = 0;
+      useMutation.mockImplementation(() => {
+        callCount++;
+        return makeMockMutation({
+          isPending: callCount === 3 ? ref(true) : ref(false),
+        });
+      });
+
+      const { isDeletingMultiple } = useSnmpAlerts();
+
+      expect(isDeletingMultiple.value).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Updated vue query in the following pages

- Sessions (only refetch interval - same as sensors for now)
Jira Story: https://jsw.ibm.com/browse/PFEBMC-5741

- Factory reset (no refetch interval)
Jira Story: https://jsw.ibm.com/browse/PFEBMC-5740

- SNMP (no refetch interval)
Jira Story: https://jsw.ibm.com/browse/PFEBMC-5748
