### PR TITLE
Raw key being displayed on Certificates page

### DIFF
--- a/src/store/modules/SecurityAndAccess/CertificatesStore.js
+++ b/src/store/modules/SecurityAndAccess/CertificatesStore.js
@@ -31,7 +31,7 @@ export const CERTIFICATE_TYPES = [
     limit: 1,
   },
 ];
-const getCertificateProp = (type, prop) => {
+export const getCertificateProp = (type, prop) => {
   const certificate = CERTIFICATE_TYPES.find(
     (certificate) => certificate.type === type,
   );
@@ -210,14 +210,13 @@ export const CertificatesStore = defineStore('certificates', {
         });
     },
     async addNewCertificate({ file, type }) {
-      const typeOfCertificate = getCertificateProp(type, 'label');
       return await api
         .post(getCertificateProp(type, 'location'), file, {
           headers: { 'Content-Type': 'application/x-pem-file' },
         })
         .then(() => this.getCertificates())
         .then(() => {
-          if (typeOfCertificate === 'HTTPS Certificate') {
+          if (type === 'HTTPS Certificate') {
             return i18n.global.t(
               'pageCertificates.toast.successAddedHTTPCertificate',
               {
@@ -276,7 +275,6 @@ export const CertificatesStore = defineStore('certificates', {
       data.CertificateString = certificateString;
       data.CertificateType = 'PEM';
       data.CertificateUri = { '@odata.id': location };
-      const typeOfCertificate = getCertificateProp(type, 'label');
       return await api
         .post(
           '/redfish/v1/CertificateService/Actions/CertificateService.ReplaceCertificate',
@@ -287,7 +285,7 @@ export const CertificatesStore = defineStore('certificates', {
           this.getCertificates();
         })
         .then(() => {
-          if (typeOfCertificate === 'HTTPS Certificate') {
+          if (type === 'HTTPS Certificate') {
             return i18n.global.t(
               'pageCertificates.toast.successReplacedHTTPCertificate',
               {

--- a/src/views/SecurityAndAccess/Certificates/Certificates.vue
+++ b/src/views/SecurityAndAccess/Certificates/Certificates.vue
@@ -152,7 +152,7 @@ import useLoadingBar from '@/components/Composables/useLoadingBarComposable';
 import useToastComposable from '@/components/Composables/useToastComposable';
 import i18n from '@/i18n';
 import eventBus from '@/eventBus';
-import { CERTIFICATE_TYPES } from '@/store/modules/SecurityAndAccess/CertificatesStore.js';
+import { getCertificateProp } from '@/store/modules/SecurityAndAccess/CertificatesStore.js';
 
 const { hideLoader, startLoader, endLoader } = useLoadingBar();
 const toast = useToastComposable();
@@ -247,7 +247,7 @@ const expiredCertificateTypes = computed(() => {
   return certificates.value.reduce((acc, val) => {
     const daysUntilExpired = getDaysUntilExpired(val.validUntil);
     if (daysUntilExpired < 0) {
-      acc.push(val.certificate);
+      acc.push(getCertificateLabel(val.certificate));
     }
     return acc;
   }, []);
@@ -256,15 +256,14 @@ const expiringCertificateTypes = computed(() => {
   return certificates.value.reduce((acc, val) => {
     const daysUntilExpired = getDaysUntilExpired(val.validUntil);
     if (daysUntilExpired < 31 && daysUntilExpired >= 0) {
-      acc.push(val.certificate);
+      acc.push(getCertificateLabel(val.certificate));
     }
     return acc;
   }, []);
 });
 
 const getCertificateLabel = (certificateType) => {
-  const certConfig = CERTIFICATE_TYPES.find((c) => c.type === certificateType);
-  return certConfig ? i18n.global.t(certConfig.labelKey) : certificateType;
+  return getCertificateProp(certificateType, 'label') || certificateType;
 };
 
 const onTableRowAction = (event, rowItem) => {
@@ -284,7 +283,7 @@ const initModalUploadCertificate = (certificate = null) => {
   eventBus.emit('upload-certificate');
 };
 const initModalDeleteCertificate = (certificate) => {
-  modalContent.value = certificate.certificate;
+  modalContent.value = getCertificateLabel(certificate.certificate);
   modalCertificate.value = certificate;
   certificate.actions.forEach((action) => {
     if (action.enabled !== undefined) {

--- a/src/views/SecurityAndAccess/Certificates/ModalGenerateCsr.vue
+++ b/src/views/SecurityAndAccess/Certificates/ModalGenerateCsr.vue
@@ -355,7 +355,10 @@ import stores from '@/store';
 import IconAdd from '@carbon/icons-vue/es/add--alt/20';
 import useToast from '@/components/Composables/useToastComposable';
 import { COUNTRY_LIST } from './CsrCountryCodes';
-import { CERTIFICATE_TYPES } from '@/store/modules/SecurityAndAccess/CertificatesStore';
+import {
+  CERTIFICATE_TYPES,
+  getCertificateProp,
+} from '@/store/modules/SecurityAndAccess/CertificatesStore';
 import useVuelidateComposable from '@/components/Composables/useVuelidateComposable';
 import i18n from '@/i18n';
 
@@ -388,7 +391,7 @@ const certificateOptions = CERTIFICATE_TYPES.reduce((arr, cert) => {
   )
     return arr;
   arr.push({
-    text: i18n.global.t(cert.labelKey),
+    text: getCertificateProp(cert.type, 'label'),
     value: cert.type,
   });
   return arr;

--- a/src/views/SecurityAndAccess/Certificates/ModalUploadCertificate.vue
+++ b/src/views/SecurityAndAccess/Certificates/ModalUploadCertificate.vue
@@ -19,7 +19,7 @@
       <template v-if="certificate !== null">
         <dl class="mb-4">
           <dt>{{ $t('pageCertificates.modal.certificateType') }}</dt>
-          <dd>{{ certificate.certificate }}</dd>
+          <dd>{{ getCertificateLabel(certificate.certificate) }}</dd>
         </dl>
       </template>
       <!-- Add new Certificate type -->
@@ -87,6 +87,10 @@ import useVuelidateComposable from '@/components/Composables/useVuelidateComposa
 import FormFile from '@/components/Global/FormFile.vue';
 import eventBus from '@/eventBus';
 import i18n from '@/i18n';
+import {
+  CERTIFICATE_TYPES,
+  getCertificateProp,
+} from '@/store/modules/SecurityAndAccess/CertificatesStore.js';
 
 const { getValidationState } = useVuelidateComposable();
 
@@ -128,9 +132,9 @@ const certificateOptions = computed(() => {
       }
       return certificate === certificate;
     })
-    .map(({ type, labelKey }) => {
+    .map(({ type }) => {
       return {
-        text: i18n.global.t(labelKey),
+        text: getCertificateProp(type, 'label'),
         value: type,
       };
     });
@@ -152,6 +156,10 @@ const fileFormat = computed(() => {
 const isNotAdmin = computed(() => {
   return props.userRoleId !== 'Administrator';
 });
+
+const getCertificateLabel = (certificateType) => {
+  return getCertificateProp(certificateType, 'label') || certificateType;
+};
 
 watch(certificateOptions, (options) => {
   if (options.length) {


### PR DESCRIPTION
- Raw key being displayed on UI for expiring and expired certificates alert message 
- All raw keys are same as UI certificate label except for CA certificate for which the raw key is 'TrustStore certificate' Comes up only during certificate replacement, deletion, and in expiration/expiry alert messages 
- Defect Link: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=794579